### PR TITLE
Added "text" and "format" fields to Content table and related classes

### DIFF
--- a/src/main/kotlin/org/wycliffeassociates/otter/jvm/persistence/database/daos/ContentDao.kt
+++ b/src/main/kotlin/org/wycliffeassociates/otter/jvm/persistence/database/daos/ContentDao.kt
@@ -68,14 +68,18 @@ class ContentDao(
                         CONTENT_ENTITY.SORT,
                         CONTENT_ENTITY.START,
                         CONTENT_ENTITY.LABEL,
-                        CONTENT_ENTITY.SELECTED_TAKE_FK
+                        CONTENT_ENTITY.SELECTED_TAKE_FK,
+                        CONTENT_ENTITY.TEXT,
+                        CONTENT_ENTITY.FORMAT
                 )
                 .values(
                         entity.collectionFk,
                         entity.sort,
                         entity.start,
                         entity.labelKey,
-                        entity.selectedTakeFk
+                        entity.selectedTakeFk,
+                        entity.text,
+                        entity.format
                 )
                 .execute()
 
@@ -115,6 +119,8 @@ class ContentDao(
                 .set(CONTENT_ENTITY.START, entity.start)
                 .set(CONTENT_ENTITY.COLLECTION_FK, entity.collectionFk)
                 .set(CONTENT_ENTITY.SELECTED_TAKE_FK, entity.selectedTakeFk)
+                .set(CONTENT_ENTITY.TEXT, entity.text)
+                .set(CONTENT_ENTITY.FORMAT, entity.format)
                 .where(CONTENT_ENTITY.ID.eq(entity.id))
                 .execute()
     }

--- a/src/main/kotlin/org/wycliffeassociates/otter/jvm/persistence/database/daos/RecordMappers.kt
+++ b/src/main/kotlin/org/wycliffeassociates/otter/jvm/persistence/database/daos/RecordMappers.kt
@@ -65,7 +65,9 @@ class RecordMappers {
                     record.getValue(CONTENT_ENTITY.LABEL),
                     record.getValue(CONTENT_ENTITY.START),
                     record.getValue(CONTENT_ENTITY.COLLECTION_FK),
-                    record.getValue(CONTENT_ENTITY.SELECTED_TAKE_FK)
+                    record.getValue(CONTENT_ENTITY.SELECTED_TAKE_FK),
+                    record.getValue(CONTENT_ENTITY.TEXT),
+                    record.getValue(CONTENT_ENTITY.FORMAT)
             )
         }
 

--- a/src/main/kotlin/org/wycliffeassociates/otter/jvm/persistence/entities/ContentEntity.kt
+++ b/src/main/kotlin/org/wycliffeassociates/otter/jvm/persistence/entities/ContentEntity.kt
@@ -6,5 +6,7 @@ data class ContentEntity(
         var labelKey: String,
         var start: Int,
         var collectionFk: Int,
-        var selectedTakeFk: Int?
+        var selectedTakeFk: Int?,
+        var text: String?,
+        var format: String?
 )

--- a/src/main/kotlin/org/wycliffeassociates/otter/jvm/persistence/repositories/mapping/ContentMapper.kt
+++ b/src/main/kotlin/org/wycliffeassociates/otter/jvm/persistence/repositories/mapping/ContentMapper.kt
@@ -12,6 +12,8 @@ class ContentMapper {
                 entity.start,
                 end,
                 selectedTake,
+                entity.text,
+                entity.format,
                 entity.id
         )
     }
@@ -23,7 +25,9 @@ class ContentMapper {
                 obj.labelKey,
                 obj.start,
                 collectionFk,
-                obj.selectedTake?.id
+                obj.selectedTake?.id,
+                obj.text,
+                obj.format
         )
     }
 

--- a/src/main/resources/sql/CreateAppDb.sql
+++ b/src/main/resources/sql/CreateAppDb.sql
@@ -52,7 +52,9 @@ CREATE TABLE IF NOT EXISTS content_entity (
     label            TEXT NOT NULL,
     selected_take_fk INTEGER REFERENCES take_entity(id),
     start            INTEGER NOT NULL,
-    sort             INTEGER NOT NULL
+    sort             INTEGER NOT NULL,
+    text             TEXT,
+    format           TEXT
 );
 
 CREATE TABLE IF NOT EXISTS content_derivative (

--- a/src/test/kotlin/org/wycliffeassociates/otter/jvm/persistence/TestDataStore.kt
+++ b/src/test/kotlin/org/wycliffeassociates/otter/jvm/persistence/TestDataStore.kt
@@ -120,6 +120,8 @@ object TestDataStore {
                     "verse1",
                     1,
                     1,
+                    null,
+                    null,
                     null
             ),
             Content(
@@ -127,7 +129,9 @@ object TestDataStore {
                     "verse42",
                     42,
                     42,
-                    takes.first()
+                    takes.first(),
+                    null,
+                    null
             )
     )
 }


### PR DESCRIPTION
This PR is blocked by the [corresponding PR in the common](https://github.com/WycliffeAssociates/otter-common/pull/81) repository. Once that is merged, this should build successfully as well.