### PR TITLE
Added 'end' to Content and 'rc_fk' to Resource

### DIFF
--- a/src/main/kotlin/org/wycliffeassociates/otter/jvm/persistence/database/daos/ContentDao.kt
+++ b/src/main/kotlin/org/wycliffeassociates/otter/jvm/persistence/database/daos/ContentDao.kt
@@ -67,6 +67,7 @@ class ContentDao(
                         CONTENT_ENTITY.COLLECTION_FK,
                         CONTENT_ENTITY.SORT,
                         CONTENT_ENTITY.START,
+                        CONTENT_ENTITY.END,
                         CONTENT_ENTITY.LABEL,
                         CONTENT_ENTITY.SELECTED_TAKE_FK,
                         CONTENT_ENTITY.TEXT,
@@ -76,6 +77,7 @@ class ContentDao(
                         entity.collectionFk,
                         entity.sort,
                         entity.start,
+                        entity.end,
                         entity.labelKey,
                         entity.selectedTakeFk,
                         entity.text,
@@ -117,6 +119,7 @@ class ContentDao(
                 .set(CONTENT_ENTITY.SORT, entity.sort)
                 .set(CONTENT_ENTITY.LABEL, entity.labelKey)
                 .set(CONTENT_ENTITY.START, entity.start)
+                .set(CONTENT_ENTITY.END, entity.end)
                 .set(CONTENT_ENTITY.COLLECTION_FK, entity.collectionFk)
                 .set(CONTENT_ENTITY.SELECTED_TAKE_FK, entity.selectedTakeFk)
                 .set(CONTENT_ENTITY.TEXT, entity.text)

--- a/src/main/kotlin/org/wycliffeassociates/otter/jvm/persistence/database/daos/RecordMappers.kt
+++ b/src/main/kotlin/org/wycliffeassociates/otter/jvm/persistence/database/daos/RecordMappers.kt
@@ -64,6 +64,7 @@ class RecordMappers {
                     record.getValue(CONTENT_ENTITY.SORT),
                     record.getValue(CONTENT_ENTITY.LABEL),
                     record.getValue(CONTENT_ENTITY.START),
+                    record.getValue(CONTENT_ENTITY.END),
                     record.getValue(CONTENT_ENTITY.COLLECTION_FK),
                     record.getValue(CONTENT_ENTITY.SELECTED_TAKE_FK),
                     record.getValue(CONTENT_ENTITY.TEXT),
@@ -76,7 +77,8 @@ class RecordMappers {
                     record.getValue(RESOURCE_LINK.ID),
                     record.getValue(RESOURCE_LINK.RESOURCE_CONTENT_FK),
                     record.getValue(RESOURCE_LINK.CONTENT_FK),
-                    record.getValue(RESOURCE_LINK.COLLECTION_FK)
+                    record.getValue(RESOURCE_LINK.COLLECTION_FK),
+                    record.getValue(RESOURCE_LINK.RC_FK)
             )
         }
 

--- a/src/main/kotlin/org/wycliffeassociates/otter/jvm/persistence/database/daos/ResourceLinkDao.kt
+++ b/src/main/kotlin/org/wycliffeassociates/otter/jvm/persistence/database/daos/ResourceLinkDao.kt
@@ -39,12 +39,14 @@ class ResourceLinkDao(
                         RESOURCE_LINK,
                         RESOURCE_LINK.RESOURCE_CONTENT_FK,
                         RESOURCE_LINK.CONTENT_FK,
-                        RESOURCE_LINK.COLLECTION_FK
+                        RESOURCE_LINK.COLLECTION_FK,
+                        RESOURCE_LINK.RC_FK
                 )
                 .values(
                         entity.resourceContentFk,
                         entity.contentFk,
-                        entity.collectionFk
+                        entity.collectionFk,
+                        entity.rc_fk
                 )
                 .execute()
 
@@ -82,6 +84,7 @@ class ResourceLinkDao(
                 .set(RESOURCE_LINK.RESOURCE_CONTENT_FK, entity.resourceContentFk)
                 .set(RESOURCE_LINK.CONTENT_FK, entity.contentFk)
                 .set(RESOURCE_LINK.COLLECTION_FK, entity.collectionFk)
+                .set(RESOURCE_LINK.RC_FK, entity.rc_fk)
                 .where(RESOURCE_LINK.ID.eq(entity.id))
                 .execute()
     }

--- a/src/main/kotlin/org/wycliffeassociates/otter/jvm/persistence/database/daos/ResourceLinkDao.kt
+++ b/src/main/kotlin/org/wycliffeassociates/otter/jvm/persistence/database/daos/ResourceLinkDao.kt
@@ -46,7 +46,7 @@ class ResourceLinkDao(
                         entity.resourceContentFk,
                         entity.contentFk,
                         entity.collectionFk,
-                        entity.rc_fk
+                        entity.rcFk
                 )
                 .execute()
 
@@ -84,7 +84,7 @@ class ResourceLinkDao(
                 .set(RESOURCE_LINK.RESOURCE_CONTENT_FK, entity.resourceContentFk)
                 .set(RESOURCE_LINK.CONTENT_FK, entity.contentFk)
                 .set(RESOURCE_LINK.COLLECTION_FK, entity.collectionFk)
-                .set(RESOURCE_LINK.RC_FK, entity.rc_fk)
+                .set(RESOURCE_LINK.RC_FK, entity.rcFk)
                 .where(RESOURCE_LINK.ID.eq(entity.id))
                 .execute()
     }

--- a/src/main/kotlin/org/wycliffeassociates/otter/jvm/persistence/entities/ContentEntity.kt
+++ b/src/main/kotlin/org/wycliffeassociates/otter/jvm/persistence/entities/ContentEntity.kt
@@ -5,6 +5,7 @@ data class ContentEntity(
         var sort: Int,
         var labelKey: String,
         var start: Int,
+        var end: Int,
         var collectionFk: Int,
         var selectedTakeFk: Int?,
         var text: String?,

--- a/src/main/kotlin/org/wycliffeassociates/otter/jvm/persistence/entities/ResourceLinkEntity.kt
+++ b/src/main/kotlin/org/wycliffeassociates/otter/jvm/persistence/entities/ResourceLinkEntity.kt
@@ -5,5 +5,5 @@ data class ResourceLinkEntity(
         var resourceContentFk: Int,
         var contentFk: Int?,
         var collectionFk: Int?,
-        var rc_fk: Int
+        var rcFk: Int
 )

--- a/src/main/kotlin/org/wycliffeassociates/otter/jvm/persistence/entities/ResourceLinkEntity.kt
+++ b/src/main/kotlin/org/wycliffeassociates/otter/jvm/persistence/entities/ResourceLinkEntity.kt
@@ -4,5 +4,6 @@ data class ResourceLinkEntity(
         var id: Int,
         var resourceContentFk: Int,
         var contentFk: Int?,
-        var collectionFk: Int?
+        var collectionFk: Int?,
+        var rc_fk: Int
 )

--- a/src/main/kotlin/org/wycliffeassociates/otter/jvm/persistence/repositories/ResourceRepository.kt
+++ b/src/main/kotlin/org/wycliffeassociates/otter/jvm/persistence/repositories/ResourceRepository.kt
@@ -68,7 +68,7 @@ class ResourceRepository(
                 .subscribeOn(Schedulers.io())
     }
 
-    override fun linkToContent(resource: Content, content: Content): Completable {
+    override fun linkToContent(resource: Content, content: Content, rcFk: Int): Completable {
         return Completable
                 .fromAction {
                     // Check if already exists
@@ -85,7 +85,8 @@ class ResourceRepository(
                                 0,
                                 resource.id,
                                 content.id,
-                                null
+                                null,
+                                rcFk
                         )
                         resourceLinkDao.insert(entity)
                     }
@@ -93,7 +94,7 @@ class ResourceRepository(
                 .subscribeOn(Schedulers.io())
     }
 
-    override fun linkToCollection(resource: Content, collection: Collection): Completable {
+    override fun linkToCollection(resource: Content, collection: Collection, rcFk: Int): Completable {
         return Completable
                 .fromAction {
                     // Check if already exists
@@ -110,7 +111,8 @@ class ResourceRepository(
                                 0,
                                 resource.id,
                                 null,
-                                collection.id
+                                collection.id,
+                                rcFk
                         )
                         resourceLinkDao.insert(entity)
                     }

--- a/src/main/kotlin/org/wycliffeassociates/otter/jvm/persistence/repositories/mapping/ContentMapper.kt
+++ b/src/main/kotlin/org/wycliffeassociates/otter/jvm/persistence/repositories/mapping/ContentMapper.kt
@@ -24,6 +24,7 @@ class ContentMapper {
                 obj.sort,
                 obj.labelKey,
                 obj.start,
+                obj.end,
                 collectionFk,
                 obj.selectedTake?.id,
                 obj.text,

--- a/src/main/resources/sql/CreateAppDb.sql
+++ b/src/main/resources/sql/CreateAppDb.sql
@@ -52,6 +52,7 @@ CREATE TABLE IF NOT EXISTS content_entity (
     label            TEXT NOT NULL,
     selected_take_fk INTEGER REFERENCES take_entity(id),
     start            INTEGER NOT NULL,
+    end              INTEGER NOT NULL,
     sort             INTEGER NOT NULL,
     text             TEXT,
     format           TEXT
@@ -86,6 +87,7 @@ CREATE TABLE IF NOT EXISTS resource_link (
     resource_content_fk INTEGER NOT NULL REFERENCES content_entity(id) ON DELETE CASCADE,
     content_fk          INTEGER REFERENCES content_entity(id) ON DELETE CASCADE,
     collection_fk       INTEGER REFERENCES collection_entity(id) ON DELETE CASCADE,
+    rc_fk               INTEGER NOT NULL REFERENCES dublin_core_entity(id),
     UNIQUE (resource_content_fk, content_fk, collection_fk),
     CONSTRAINT ensure_at_least_one_not_null
         CHECK ((collection_fk is NOT NULL) or (content_fk is NOT NULL)),


### PR DESCRIPTION
`end` was a field in the `Content` model object (Content.kt in the common repo), but it had not been added to the Content table. This PR accomplishes this.

Additionally, I added `rc_fk` to the Resource (`resource_link`) table. This addition will allow us to retrieve specific types of resources (tn, tq, etc).

In ResourceRepository.kt, I had to add an `rcFk` parameter to several functions since the `Collection` object's `resourceContainer` field is nullable, but `rc_fk ` is not nullable in the Resource table. This doesn't feel very good. Why do we allow `Collection`'s `resourceContainer` field to be null?

This brings up another point. Should `rc_fk` in fact be non-nullable? I think so, since we are not allowing users to create their own notes (if we did someday though, these would not be tied to a resource container.)

This code will not build until the corresponding PR #[83](https://github.com/WycliffeAssociates/otter-common/pull/83) in the common repo is merged.