### PR TITLE
Kj takecards widgets

### DIFF
--- a/src/main/kotlin/org/wycliffeassociates/otter/jvm/app/ui/takemanagement/view/TakeManagementView.kt
+++ b/src/main/kotlin/org/wycliffeassociates/otter/jvm/app/ui/takemanagement/view/TakeManagementView.kt
@@ -24,17 +24,17 @@ import org.wycliffeassociates.otter.jvm.app.theme.AppStyles
 import org.wycliffeassociates.otter.jvm.app.ui.takemanagement.TakeContext
 import org.wycliffeassociates.otter.jvm.app.ui.takemanagement.viewmodel.TakeManagementViewModel
 import org.wycliffeassociates.otter.jvm.app.widgets.progressdialog.progressdialog
-import org.wycliffeassociates.otter.jvm.app.widgets.takecard.TakeCard
-import org.wycliffeassociates.otter.jvm.app.widgets.takecard.takecard
+import org.wycliffeassociates.otter.jvm.app.widgets.takecard.OldTakeCard
+import org.wycliffeassociates.otter.jvm.app.widgets.takecard.oldtakecard
 import tornadofx.*
 
 class TakeManagementView : Fragment() {
     private val viewModel: TakeManagementViewModel by inject()
 
     // The currently selected take
-    private var selectedTakeProperty = SimpleObjectProperty<TakeCard>()
+    private var selectedTakeProperty = SimpleObjectProperty<OldTakeCard>()
     // Take at the top to compare to an existing selected take
-    private var draggingTakeProperty = SimpleObjectProperty<TakeCard>()
+    private var draggingTakeProperty = SimpleObjectProperty<OldTakeCard>()
 
     // Drag target to show when drag action in progress
     private var dragTarget: StackPane by singleAssign()
@@ -198,7 +198,7 @@ class TakeManagementView : Fragment() {
         val target = evt.target as Node
 
         // Remove from the flow pane
-        val takeCard = target.findParentOfType(TakeCard::class) as TakeCard
+        val takeCard = target.findParentOfType(OldTakeCard::class) as OldTakeCard
         if (takeCard.parent == takesFlowPane) {
             takeCard.removeFromParent()
             draggingTakeProperty.value = takeCard
@@ -262,14 +262,14 @@ class TakeManagementView : Fragment() {
 
     private fun sortTakesFlowPane(flowPane: FlowPane) {
         flowPane.children.setAll(flowPane.children.sortedBy {
-            (it as TakeCard).take.number
+            (it as OldTakeCard).take.number
         })
         //add the newTakeCard here after we have sorted all other takes by take number
         flowPane.children.add(0, createRecordCard())
     }
 
-    private fun createTakeCard(take: Take): TakeCard {
-        return takecard(take, viewModel.audioPlayer(), messages["take"]) {
+    private fun createTakeCard(take: Take): OldTakeCard {
+        return oldtakecard(take, viewModel.audioPlayer(), messages["take"]) {
             addClass(TakeManagementStyles.takeCard)
             playedProperty.onChange {
                 if (it) viewModel.setTakePlayed(take)

--- a/src/main/kotlin/org/wycliffeassociates/otter/jvm/app/widgets/takecard/OldTakeCard.kt
+++ b/src/main/kotlin/org/wycliffeassociates/otter/jvm/app/widgets/takecard/OldTakeCard.kt
@@ -60,7 +60,7 @@ class OldTakeCard(val take: Take, player: IAudioPlayer, val takePrefix: String) 
                     alignment = Pos.CENTER
                     simpleAudioPlayer = simpleaudioplayer(take.path, player) {
                         vgrow = Priority.ALWAYS
-                        addClass(OldTakeCardStyles.takeprogressBar)
+                        addClass(OldTakeCardStyles.takeProgressBar)
                         isAudioPlaying.bind(isPlaying)
                     }
                     add(simpleAudioPlayer)

--- a/src/main/kotlin/org/wycliffeassociates/otter/jvm/app/widgets/takecard/OldTakeCard.kt
+++ b/src/main/kotlin/org/wycliffeassociates/otter/jvm/app/widgets/takecard/OldTakeCard.kt
@@ -15,7 +15,7 @@ import org.wycliffeassociates.otter.jvm.app.widgets.SimpleAudioPlayer
 import org.wycliffeassociates.otter.jvm.app.widgets.simpleaudioplayer
 import tornadofx.*
 
-class TakeCard(val take: Take, player: IAudioPlayer, val takePrefix: String) : AnchorPane() {
+class OldTakeCard(val take: Take, player: IAudioPlayer, val takePrefix: String) : AnchorPane() {
     val playedProperty = SimpleBooleanProperty(take.played)
 
     var deleteButton: Button by singleAssign()
@@ -29,10 +29,10 @@ class TakeCard(val take: Take, player: IAudioPlayer, val takePrefix: String) : A
     private val isAudioPlaying: SimpleBooleanProperty = SimpleBooleanProperty()
 
     init {
-        importStylesheet<TakeCardStyles>()
-        addClass(TakeCardStyles.defaultTakeCard)
+        importStylesheet<OldTakeCardStyles>()
+        addClass(OldTakeCardStyles.defaultTakeCard)
         vbox {
-            addClass(TakeCardStyles.content)
+            addClass(OldTakeCardStyles.content)
             //the top bar of the take card
             hbox(10) {
                 style {
@@ -41,10 +41,10 @@ class TakeCard(val take: Take, player: IAudioPlayer, val takePrefix: String) : A
                 hbox(10.0) {
                     hgrow = Priority.ALWAYS
                     alignment = Pos.CENTER_LEFT
-                    takeNumberLabel = label("$takePrefix %02d".format(take.number), TakeCardStyles.draggingIcon())
-                    takeNumberLabel.addClass(TakeCardStyles.takeNumberLabel)
+                    takeNumberLabel = label("$takePrefix %02d".format(take.number), OldTakeCardStyles.draggingIcon())
+                    takeNumberLabel.addClass(OldTakeCardStyles.takeNumberLabel)
                     timestampLabel = label(take.timestamp.toString())
-                    timestampLabel.addClass(TakeCardStyles.timestampLabel)
+                    timestampLabel.addClass(OldTakeCardStyles.timestampLabel)
                 }
                 hbox {
                     alignment = Pos.TOP_RIGHT
@@ -60,24 +60,24 @@ class TakeCard(val take: Take, player: IAudioPlayer, val takePrefix: String) : A
                     alignment = Pos.CENTER
                     simpleAudioPlayer = simpleaudioplayer(take.path, player) {
                         vgrow = Priority.ALWAYS
-                        addClass(TakeCardStyles.takeprogressBar)
+                        addClass(OldTakeCardStyles.takeprogressBar)
                         isAudioPlaying.bind(isPlaying)
                     }
                     add(simpleAudioPlayer)
                 }
                 hbox(15.0) {
-                    playButton = JFXButton("PLAY", TakeCardStyles.playIcon())
-                            .addClass(TakeCardStyles.defaultButton)
+                    playButton = JFXButton("PLAY", OldTakeCardStyles.playIcon())
+                            .addClass(OldTakeCardStyles.defaultButton)
                             .apply {
                                 isDisableVisualFocus = true
                                 action {
                                     simpleAudioPlayer.buttonPressed()
                                 }
                             }
-                    editButton = JFXButton("EDIT", TakeCardStyles.editIcon())
-                            .addClass(TakeCardStyles.defaultButton)
+                    editButton = JFXButton("EDIT", OldTakeCardStyles.editIcon())
+                            .addClass(OldTakeCardStyles.defaultButton)
                             .apply {
-                                textFill = TakeCardStyles.defaultGreen
+                                textFill = OldTakeCardStyles.defaultGreen
                                 isDisableVisualFocus = true
                             }
 
@@ -98,13 +98,13 @@ class TakeCard(val take: Take, player: IAudioPlayer, val takePrefix: String) : A
             when (isAudioPlaying.value) {
                 true -> {
                     playButton.apply {
-                        graphic = TakeCardStyles.pauseIcon()
+                        graphic = OldTakeCardStyles.pauseIcon()
                         text = "PAUSE"
                     }
                 }
                 false -> {
                     playButton.apply {
-                        graphic = TakeCardStyles.playIcon()
+                        graphic = OldTakeCardStyles.playIcon()
                         text = "PLAY"
                     }
                 }
@@ -113,8 +113,8 @@ class TakeCard(val take: Take, player: IAudioPlayer, val takePrefix: String) : A
     }
 }
 
-fun takecard(take: Take, player: IAudioPlayer, takePrefix: String, init: TakeCard.() -> Unit = {}): TakeCard {
-    val takeCard = TakeCard(take, player, takePrefix)
+fun oldtakecard(take: Take, player: IAudioPlayer, takePrefix: String, init: OldTakeCard.() -> Unit = {}): OldTakeCard {
+    val takeCard = OldTakeCard(take, player, takePrefix)
     takeCard.init()
     return takeCard
 }

--- a/src/main/kotlin/org/wycliffeassociates/otter/jvm/app/widgets/takecard/OldTakeCardStyles.kt
+++ b/src/main/kotlin/org/wycliffeassociates/otter/jvm/app/widgets/takecard/OldTakeCardStyles.kt
@@ -11,7 +11,7 @@ import javafx.scene.text.FontWeight
 import org.wycliffeassociates.otter.jvm.app.images.ImageLoader
 import tornadofx.*
 
-class TakeCardStyles : Stylesheet() {
+class OldTakeCardStyles : Stylesheet() {
     companion object {
         val defaultTakeCard by cssclass()
         val badge by cssclass()

--- a/src/main/kotlin/org/wycliffeassociates/otter/jvm/app/widgets/takecard/OldTakeCardStyles.kt
+++ b/src/main/kotlin/org/wycliffeassociates/otter/jvm/app/widgets/takecard/OldTakeCardStyles.kt
@@ -20,7 +20,7 @@ class OldTakeCardStyles : Stylesheet() {
         val takeNumberLabel by cssclass()
         val timestampLabel by cssclass()
         val defaultButton by cssclass()
-        val takeprogressBar by cssclass()
+        val takeProgressBar by cssclass()
         val defaultGreen : Color = c("#58BD2F")
 
         fun pauseIcon() = MaterialIconView(MaterialIcon.PAUSE, "30px")
@@ -79,7 +79,7 @@ class OldTakeCardStyles : Stylesheet() {
             }
         }
 
-        takeprogressBar {
+        takeProgressBar {
             track {
                 backgroundColor += Color.LIGHTGRAY
                 minHeight = 40.px

--- a/src/main/kotlin/org/wycliffeassociates/otter/jvm/app/widgets/takecard/ResourceTakeCardSkin.kt
+++ b/src/main/kotlin/org/wycliffeassociates/otter/jvm/app/widgets/takecard/ResourceTakeCardSkin.kt
@@ -26,7 +26,7 @@ class ResourceTakeCardSkin(control: TakeCard) : TakeCardSkin(control) {
                     addClass(TakeCardStyles.takeNumberLabel)
                 }
                 add(control.simpleAudioPlayer.apply {
-                    addClass(TakeCardStyles.takeprogressBar)
+                    addClass(TakeCardStyles.takeProgressBar)
                     vgrow = Priority.ALWAYS
                     hgrow = Priority.ALWAYS
                 })

--- a/src/main/kotlin/org/wycliffeassociates/otter/jvm/app/widgets/takecard/ResourceTakeCardSkin.kt
+++ b/src/main/kotlin/org/wycliffeassociates/otter/jvm/app/widgets/takecard/ResourceTakeCardSkin.kt
@@ -1,0 +1,51 @@
+package org.wycliffeassociates.otter.jvm.app.widgets.takecard
+
+import com.jfoenix.controls.JFXButton
+import de.jensd.fx.glyphs.materialicons.MaterialIcon
+import de.jensd.fx.glyphs.materialicons.MaterialIconView
+import javafx.geometry.Pos
+import javafx.scene.layout.Priority
+import javafx.scene.layout.VBox
+import tornadofx.*
+
+class ResourceTakeCardSkin(control: TakeCard) : TakeCardSkin(control) {
+
+    private var container: VBox
+
+    init {
+        importStylesheet<TakeCardStyles>()
+
+        container = VBox().apply {
+            addClass(TakeCardStyles.resourceTakeCard)
+
+            hbox(10.0) {
+                addClass(TakeCardStyles.topHalf)
+                alignment = Pos.CENTER_LEFT
+
+                label("%02d.".format(control.take.number), TakeCardStyles.draggingIcon()) {
+                    addClass(TakeCardStyles.takeNumberLabel)
+                }
+                add(control.simpleAudioPlayer.apply {
+                    addClass(TakeCardStyles.takeprogressBar)
+                    vgrow = Priority.ALWAYS
+                    hgrow = Priority.ALWAYS
+                })
+            }
+
+            hbox {
+                add(JFXButton("", MaterialIconView(MaterialIcon.EDIT, "18px")))
+                alignment = Pos.CENTER
+                hbox {
+                    hgrow = Priority.ALWAYS
+                    alignment = Pos.CENTER
+                    add(JFXButton("", MaterialIconView(MaterialIcon.SKIP_PREVIOUS, "18px")))
+                    add(playButton)
+                    add(JFXButton("", MaterialIconView(MaterialIcon.FAST_FORWARD, "18px")))
+                }
+                add(JFXButton("", MaterialIconView(MaterialIcon.DELETE, "18px")))
+            }
+        }
+
+        children.setAll(container)
+    }
+}

--- a/src/main/kotlin/org/wycliffeassociates/otter/jvm/app/widgets/takecard/ScriptureTakeCardSkin.kt
+++ b/src/main/kotlin/org/wycliffeassociates/otter/jvm/app/widgets/takecard/ScriptureTakeCardSkin.kt
@@ -1,0 +1,81 @@
+package org.wycliffeassociates.otter.jvm.app.widgets.takecard
+
+import com.jfoenix.controls.JFXButton
+import de.jensd.fx.glyphs.materialicons.MaterialIcon
+import de.jensd.fx.glyphs.materialicons.MaterialIconView
+import javafx.geometry.Pos
+import javafx.scene.layout.Priority
+import javafx.scene.layout.VBox
+import tornadofx.*
+import tornadofx.FX.Companion.messages
+
+class ScriptureTakeCardSkin(control: TakeCard) : TakeCardSkin(control) {
+
+    private var container: VBox
+
+    init {
+        importStylesheet<TakeCardStyles>()
+
+        container = VBox().apply {
+            anchorpane {
+                addClass(TakeCardStyles.scriptureTakeCard)
+                vbox {
+                    addClass(TakeCardStyles.content)
+                    //the top bar of the take card
+                    hbox(10) {
+                        style {
+                            maxHeight = 75.0.px
+                        }
+                        hbox(10.0) {
+                            hgrow = Priority.ALWAYS
+                            alignment = Pos.CENTER_LEFT
+                            label(
+                                "${messages["take"]} %02d".format(control.take.number),
+                                TakeCardStyles.draggingIcon()
+                            ) {
+                                addClass(TakeCardStyles.takeNumberLabel)
+                            }
+                            label(control.take.createdTimestamp.toString()) {
+                                addClass(TakeCardStyles.timestampLabel)
+                            }
+                        }
+                        hbox {
+                            alignment = Pos.TOP_RIGHT
+                            hgrow = Priority.SOMETIMES
+                            add(JFXButton(messages["delete"], MaterialIconView(MaterialIcon.DELETE, "18px")))
+                        }
+                    }
+                    // waveform and audio control buttons
+                    vbox(15.0) {
+                        vgrow = Priority.ALWAYS
+                        alignment = Pos.CENTER
+                        hbox {
+                            alignment = Pos.CENTER
+                            add(control.simpleAudioPlayer.apply {
+                                addClass(TakeCardStyles.takeprogressBar)
+                            })
+                        }
+                        hbox(15.0) {
+                            add(playButton.addClass(TakeCardStyles.defaultButton))
+                            add(
+                                JFXButton(messages["edit"], MaterialIconView(MaterialIcon.EDIT, "18px").apply {
+                                    fill = TakeCardStyles.defaultGreen
+                                }).apply {
+                                    addClass(TakeCardStyles.defaultButton)
+                                    addClass(TakeCardStyles.editButton)
+                                }
+                            )
+                        }
+                    }
+                    anchorpaneConstraints {
+                        topAnchor = 0.0
+                        bottomAnchor = 0.0
+                        leftAnchor = 0.0
+                        rightAnchor = 0.0
+                    }
+                }
+            }
+        }
+        children.addAll(container)
+    }
+}

--- a/src/main/kotlin/org/wycliffeassociates/otter/jvm/app/widgets/takecard/ScriptureTakeCardSkin.kt
+++ b/src/main/kotlin/org/wycliffeassociates/otter/jvm/app/widgets/takecard/ScriptureTakeCardSkin.kt
@@ -52,7 +52,7 @@ class ScriptureTakeCardSkin(control: TakeCard) : TakeCardSkin(control) {
                         hbox {
                             alignment = Pos.CENTER
                             add(control.simpleAudioPlayer.apply {
-                                addClass(TakeCardStyles.takeprogressBar)
+                                addClass(TakeCardStyles.takeProgressBar)
                             })
                         }
                         hbox(15.0) {

--- a/src/main/kotlin/org/wycliffeassociates/otter/jvm/app/widgets/takecard/TakeCard.kt
+++ b/src/main/kotlin/org/wycliffeassociates/otter/jvm/app/widgets/takecard/TakeCard.kt
@@ -1,0 +1,35 @@
+package org.wycliffeassociates.otter.jvm.app.widgets.takecard
+
+import javafx.beans.property.SimpleBooleanProperty
+import javafx.scene.control.Control
+import javafx.scene.control.Skin
+import org.wycliffeassociates.otter.jvm.app.widgets.simpleaudioplayer
+import org.wycliffeassociates.otter.common.data.workbook.Take
+import org.wycliffeassociates.otter.common.device.IAudioPlayer
+
+class TakeCard(val take: Take, player: IAudioPlayer) : Control() {
+    val isAudioPlayingProperty = SimpleBooleanProperty()
+
+    val simpleAudioPlayer = simpleaudioplayer(take.file, player) {
+        isAudioPlayingProperty.bind(isPlaying)
+    }
+}
+
+private fun createTakeCard(
+    take: Take, player: IAudioPlayer,
+    skinFactory: (TakeCard) -> Skin<TakeCard>,
+    init: TakeCard.() -> Unit = {}
+): TakeCard {
+    val tc = TakeCard(take, player)
+    tc.skin = skinFactory(tc)
+    tc.init()
+    return tc
+}
+
+fun scripturetakecard(take: Take, player: IAudioPlayer, init: TakeCard.() -> Unit = {}): TakeCard {
+    return createTakeCard(take, player, { ScriptureTakeCardSkin(it) }, init)
+}
+
+fun resourcetakecard(take: Take, player: IAudioPlayer, init: TakeCard.() -> Unit = {}): TakeCard {
+    return createTakeCard(take, player, { ResourceTakeCardSkin(it) }, init)
+}

--- a/src/main/kotlin/org/wycliffeassociates/otter/jvm/app/widgets/takecard/TakeCard.kt
+++ b/src/main/kotlin/org/wycliffeassociates/otter/jvm/app/widgets/takecard/TakeCard.kt
@@ -8,10 +8,22 @@ import org.wycliffeassociates.otter.common.data.workbook.Take
 import org.wycliffeassociates.otter.common.device.IAudioPlayer
 
 class TakeCard(val take: Take, player: IAudioPlayer) : Control() {
+
     val isAudioPlayingProperty = SimpleBooleanProperty()
 
     val simpleAudioPlayer = simpleaudioplayer(take.file, player) {
         isAudioPlayingProperty.bind(isPlaying)
+    }
+
+    init {
+        addEventHandler(TakeEvent.PLAY) {
+            simpleAudioPlayer.buttonPressed()
+        }
+        addEventHandler(TakeEvent.PAUSE) {
+            if (isAudioPlayingProperty.get()) {
+                simpleAudioPlayer.buttonPressed()
+            }
+        }
     }
 }
 

--- a/src/main/kotlin/org/wycliffeassociates/otter/jvm/app/widgets/takecard/TakeCardSkin.kt
+++ b/src/main/kotlin/org/wycliffeassociates/otter/jvm/app/widgets/takecard/TakeCardSkin.kt
@@ -1,0 +1,28 @@
+package org.wycliffeassociates.otter.jvm.app.widgets.takecard
+
+import com.jfoenix.controls.JFXButton
+import de.jensd.fx.glyphs.materialicons.MaterialIcon
+import de.jensd.fx.glyphs.materialicons.MaterialIconView
+import javafx.scene.control.SkinBase
+import tornadofx.*
+
+abstract class TakeCardSkin(control: TakeCard) : SkinBase<TakeCard>(control) {
+
+    val playButton = JFXButton()
+    val defaultPlayPauseIconSize = 30
+    // These can be overridden
+    open val playIconView = MaterialIconView(MaterialIcon.PLAY_ARROW, "${defaultPlayPauseIconSize}px")
+    open val pauseIconView = MaterialIconView(MaterialIcon.PAUSE, "${defaultPlayPauseIconSize}px")
+
+    init {
+        // If playIconView is overriden in child class, the graphic needs to be set in the child class
+        playButton.graphic = playIconView
+
+        control.isAudioPlayingProperty.onChange {
+            playButton.graphic = when(it) {
+                true -> pauseIconView
+                false -> playIconView
+            }
+        }
+    }
+}

--- a/src/main/kotlin/org/wycliffeassociates/otter/jvm/app/widgets/takecard/TakeCardSkin.kt
+++ b/src/main/kotlin/org/wycliffeassociates/otter/jvm/app/widgets/takecard/TakeCardSkin.kt
@@ -24,5 +24,14 @@ abstract class TakeCardSkin(control: TakeCard) : SkinBase<TakeCard>(control) {
                 false -> playIconView
             }
         }
+
+        playButton.action {
+            skinnable.fireEvent(TakeEvent(
+                when (control.isAudioPlayingProperty.get()) {
+                    true -> TakeEvent.PAUSE
+                    false -> TakeEvent.PLAY
+                }
+            ))
+        }
     }
 }

--- a/src/main/kotlin/org/wycliffeassociates/otter/jvm/app/widgets/takecard/TakeCardStyles.kt
+++ b/src/main/kotlin/org/wycliffeassociates/otter/jvm/app/widgets/takecard/TakeCardStyles.kt
@@ -19,7 +19,7 @@ class TakeCardStyles : Stylesheet() {
         val takeNumberLabel by cssclass()
         val timestampLabel by cssclass()
         val defaultButton by cssclass()
-        val takeprogressBar by cssclass()
+        val takeProgressBar by cssclass()
         val editButton by cssclass()
         val topHalf by cssclass()
         val defaultGreen : Color = c("#58BD2F")
@@ -37,7 +37,7 @@ class TakeCardStyles : Stylesheet() {
             fontWeight = FontWeight.BOLD
         }
 
-        takeprogressBar {
+        takeProgressBar {
             track {
                 backgroundColor += Color.LIGHTGRAY
                 backgroundRadius += box(5.0.px)
@@ -59,7 +59,7 @@ class TakeCardStyles : Stylesheet() {
                 borderColor += box(Color.TRANSPARENT, Color.TRANSPARENT, c("C9C8C8"), Color.TRANSPARENT)
                 borderWidth += box(1.px)
             }
-            takeprogressBar {
+            takeProgressBar {
                 track {
                     minHeight = 30.px
                 }
@@ -123,7 +123,7 @@ class TakeCardStyles : Stylesheet() {
                 textFill = TakeCardStyles.defaultGreen
             }
 
-            takeprogressBar {
+            takeProgressBar {
                 track {
                     minHeight = 40.px
                 }

--- a/src/main/kotlin/org/wycliffeassociates/otter/jvm/app/widgets/takecard/TakeCardStyles.kt
+++ b/src/main/kotlin/org/wycliffeassociates/otter/jvm/app/widgets/takecard/TakeCardStyles.kt
@@ -1,0 +1,136 @@
+package org.wycliffeassociates.otter.jvm.app.widgets.takecard
+
+import javafx.scene.effect.DropShadow
+import javafx.scene.paint.Color
+import javafx.scene.text.FontPosture
+import javafx.scene.text.FontWeight
+import org.wycliffeassociates.otter.jvm.app.images.ImageLoader
+import org.wycliffeassociates.otter.jvm.app.theme.AppTheme
+import tornadofx.*
+
+class TakeCardStyles : Stylesheet() {
+
+    companion object {
+        val scriptureTakeCard by cssclass()
+        val resourceTakeCard by cssclass()
+        val badge by cssclass()
+        val iconStyle by cssclass()
+        val content by cssclass()
+        val takeNumberLabel by cssclass()
+        val timestampLabel by cssclass()
+        val defaultButton by cssclass()
+        val takeprogressBar by cssclass()
+        val editButton by cssclass()
+        val topHalf by cssclass()
+        val defaultGreen : Color = c("#58BD2F")
+        val grey = c("#C9C8C8")
+
+        fun draggingIcon() = ImageLoader.load(
+            ClassLoader.getSystemResourceAsStream("images/baseline-drag_indicator-24px.svg"),
+            ImageLoader.Format.SVG
+        )
+    }
+
+    init {
+        takeNumberLabel {
+            fontSize = 16.px
+            fontWeight = FontWeight.BOLD
+        }
+
+        takeprogressBar {
+            track {
+                backgroundColor += Color.LIGHTGRAY
+                backgroundRadius += box(5.0.px)
+            }
+            bar {
+                backgroundColor += c("#0094F0")
+                backgroundRadius += box(5.0.px)
+            }
+        }
+
+        // RESOURCE TAKE CARD specific styles
+        resourceTakeCard {
+            minHeight = 80.px
+            maxWidth = 500.px
+            borderColor += box(grey)
+            borderRadius += box(5.px)
+            topHalf {
+                padding = box(4.px, 5.px, 5.px, 5.px)
+                borderColor += box(Color.TRANSPARENT, Color.TRANSPARENT, c("C9C8C8"), Color.TRANSPARENT)
+                borderWidth += box(1.px)
+            }
+            takeprogressBar {
+                track {
+                    minHeight = 30.px
+                }
+                bar {
+                    minHeight = 30.px
+                }
+            }
+        }
+
+        // SCRIPTURE TAKE CARD specific styles
+        scriptureTakeCard {
+            borderRadius += box(5.px)
+            borderColor += box(AppTheme.colors.imagePlaceholder)
+            borderWidth += box(1.px)
+            backgroundColor += AppTheme.colors.cardBackground
+            label {
+                textFill = AppTheme.colors.defaultText
+            }
+            minWidth = 348.px
+            maxWidth = minWidth
+            minHeight = 200.px
+            maxHeight = minHeight
+            backgroundRadius += box(5.px)
+            badge {
+                backgroundColor += AppTheme.colors.appRed
+                backgroundRadius += box(0.px, 10.px, 0.px, 10.px)
+                padding = box(8.px)
+                iconStyle {
+                    fill = Color.WHITE
+                }
+            }
+            padding = box(5.px)
+            content {
+                padding = box(10.px)
+            }
+            takeNumberLabel {
+                graphicTextGap = 7.5.px
+            }
+            timestampLabel {
+                fontSize = 12.px
+                fontWeight = FontWeight.LIGHT
+                fontStyle = FontPosture.ITALIC
+                textFill = Color.LIGHTGRAY
+                padding = box(2.5.px)
+            }
+            button {
+                backgroundColor += Color.TRANSPARENT
+            }
+            defaultButton {
+                minHeight = 40.px
+                minWidth = 150.px
+                borderRadius += box(5.0.px)
+                backgroundRadius += box(5.0.px)
+                borderColor += box(Color.LIGHTGRAY)
+                borderWidth += box(0.5.px)
+                effect = DropShadow(1.0,2.0,2.0,Color.LIGHTGRAY)
+                backgroundColor += Color.WHITE
+            }
+
+            editButton {
+                textFill = TakeCardStyles.defaultGreen
+            }
+
+            takeprogressBar {
+                track {
+                    minHeight = 40.px
+                }
+                bar {
+                    minHeight = 40.px
+                }
+            }
+        }
+    }
+}

--- a/src/main/kotlin/org/wycliffeassociates/otter/jvm/app/widgets/takecard/TakeEvent.kt
+++ b/src/main/kotlin/org/wycliffeassociates/otter/jvm/app/widgets/takecard/TakeEvent.kt
@@ -1,0 +1,12 @@
+package org.wycliffeassociates.otter.jvm.app.widgets.takecard
+
+import javafx.event.Event
+import javafx.event.EventType
+
+class TakeEvent(type: EventType<TakeEvent>) : Event(type) {
+
+    companion object {
+        val PLAY: EventType<TakeEvent> = EventType("PLAY")
+        val PAUSE: EventType<TakeEvent> = EventType("PAUSE")
+    }
+}


### PR DESCRIPTION
This PR is only for scripture and resource take card widgets.

To test, please check out [kj-takecards-testapp](https://github.com/WycliffeAssociates/otter-jvm/tree/kj-takecards-testapp) and run `main` in **ResourceTakesApp.kt**. This branch is not intended to be merged.

To change the skin of the take card from the resource skin to the scripture skin, go to **TakeCard.kt** and change **line 46** `ResourceTakeCardSkin` to `ScriptureTakeCardSkin`.

Try playing and pausing one of the takes. Then, while one take is playing, try playing another take. It will pause the currently playing take.

The previously existing **TakeCard.kt** and **TakeCardStyles.kt** have been renamed to **OldTakeCard.kt** and **OldTakeCardStyles.kt** respectively, so that existing functionality is not affected. These files will be removed at a later date when the new take cards are fully integrated. This rename may be undesirable and can be changed- it was simply a way to get this PR out for comments faster.