### PR TITLE
Reduced main screen size

### DIFF
--- a/src/main/kotlin/org/wycliffeassociates/otter/jvm/app/ui/mainscreen/view/MainScreenStyles.kt
+++ b/src/main/kotlin/org/wycliffeassociates/otter/jvm/app/ui/mainscreen/view/MainScreenStyles.kt
@@ -17,8 +17,8 @@ class MainScreenStyles : Stylesheet() {
     init {
 
         main {
-            prefWidth = Screen.getPrimary().visualBounds.width.px - 20.0
-            prefHeight = Screen.getPrimary().visualBounds.height.px - 20.0
+            prefWidth = Screen.getPrimary().visualBounds.width.px - 100.0
+            prefHeight = Screen.getPrimary().visualBounds.height.px - 100.0
         }
 
         // this gets compiled down to list-menu


### PR DESCRIPTION
Once the file menu is removed from the top, we will revert this back to -50.0 for both width and height.