### PR TITLE
Workbook Header

### DIFF
--- a/src/main/kotlin/org/wycliffeassociates/otter/jvm/app/widgets/workbookheader/WorkbookHeader.kt
+++ b/src/main/kotlin/org/wycliffeassociates/otter/jvm/app/widgets/workbookheader/WorkbookHeader.kt
@@ -1,0 +1,83 @@
+package org.wycliffeassociates.otter.jvm.app.widgets.workbookheader
+
+import com.jfoenix.controls.JFXCheckBox
+import javafx.beans.property.SimpleDoubleProperty
+import javafx.beans.property.SimpleObjectProperty
+import javafx.beans.property.SimpleStringProperty
+import javafx.scene.layout.Priority
+import javafx.scene.layout.VBox
+import javafx.scene.paint.Color
+import org.wycliffeassociates.otter.jvm.statusindicator.control.statusindicator
+import tornadofx.*
+import java.util.function.Predicate
+
+data class FilterOption<T>(val text: String, val predicate: Predicate<T>)
+
+class WorkbookHeader<T> : VBox() {
+
+    val labelTextProperty = SimpleStringProperty()
+    var labelText by labelTextProperty
+
+    val filterOptionProperty = SimpleObjectProperty<FilterOption<T>?>()
+    var filterOption by filterOptionProperty
+
+    val progressBarTrackFillProperty = SimpleObjectProperty<Color>(Color.ORANGE)
+    var progressBarTrackFill by progressBarTrackFillProperty
+
+    val workbookProgressProperty = SimpleDoubleProperty(0.5)
+    var workbookProgress by workbookProgressProperty
+
+    private val filterOptionTextProperty = SimpleStringProperty()
+
+    init {
+        importStylesheet<WorkbookHeaderStyles>()
+
+        filterOptionProperty.onChange {
+            filterOptionTextProperty.set(it?.text)
+        }
+
+        addClass(WorkbookHeaderStyles.workbookHeader)
+        spacing = 10.0
+        hbox {
+            label(labelTextProperty) {
+                managedProperty().bind(!labelTextProperty.isEmpty)
+            }
+            region {
+                hgrow = Priority.ALWAYS
+            }
+            add(
+                JFXCheckBox().apply {
+                    isDisableVisualFocus = true
+                    textProperty().bind(filterOptionTextProperty)
+                    managedProperty().bind(filterOptionProperty.isNotNull)
+                    visibleProperty().bind(filterOptionProperty.isNotNull)
+                    action {
+                        if (isSelected) {
+                            // TODO: Tell view model to filter list
+                        } else {
+                            // TODO: Tell view model to remove filter from list
+                        }
+                    }
+                }
+            )
+        }
+        add(
+            statusindicator {
+                hgrow = Priority.ALWAYS
+                primaryFillProperty().bind(progressBarTrackFillProperty)
+                accentFillProperty.bind(progressBarTrackFillProperty)
+                trackFill = Color.LIGHTGRAY
+                prefHeight = 15.0
+                barHeight = 18.0
+                indicatorRadius = 10.0
+                progressProperty().bind(workbookProgressProperty)
+            }
+        )
+    }
+}
+
+fun <T> workbookheader(init: WorkbookHeader<T>.() -> Unit = {}): WorkbookHeader<T> {
+    val wh = WorkbookHeader<T>()
+    wh.init()
+    return wh
+}

--- a/src/main/kotlin/org/wycliffeassociates/otter/jvm/app/widgets/workbookheader/WorkbookHeader.kt
+++ b/src/main/kotlin/org/wycliffeassociates/otter/jvm/app/widgets/workbookheader/WorkbookHeader.kt
@@ -1,25 +1,26 @@
 package org.wycliffeassociates.otter.jvm.app.widgets.workbookheader
 
 import com.jfoenix.controls.JFXCheckBox
+import javafx.beans.property.SimpleBooleanProperty
 import javafx.beans.property.SimpleDoubleProperty
 import javafx.beans.property.SimpleObjectProperty
 import javafx.beans.property.SimpleStringProperty
+import javafx.scene.layout.BorderStrokeStyle
 import javafx.scene.layout.Priority
 import javafx.scene.layout.VBox
 import javafx.scene.paint.Color
 import org.wycliffeassociates.otter.jvm.statusindicator.control.statusindicator
 import tornadofx.*
-import java.util.function.Predicate
 
-data class FilterOption<T>(val text: String, val predicate: Predicate<T>)
-
-class WorkbookHeader<T> : VBox() {
+class WorkbookHeader : VBox() {
 
     val labelTextProperty = SimpleStringProperty()
     var labelText by labelTextProperty
 
-    val filterOptionProperty = SimpleObjectProperty<FilterOption<T>?>()
-    var filterOption by filterOptionProperty
+    val filterTextProperty = SimpleStringProperty()
+    var filterText by filterTextProperty
+
+    val isFilterOnProperty = SimpleBooleanProperty()
 
     val progressBarTrackFillProperty = SimpleObjectProperty<Color>(Color.ORANGE)
     var progressBarTrackFill by progressBarTrackFillProperty
@@ -27,14 +28,8 @@ class WorkbookHeader<T> : VBox() {
     val workbookProgressProperty = SimpleDoubleProperty(0.5)
     var workbookProgress by workbookProgressProperty
 
-    private val filterOptionTextProperty = SimpleStringProperty()
-
     init {
         importStylesheet<WorkbookHeaderStyles>()
-
-        filterOptionProperty.onChange {
-            filterOptionTextProperty.set(it?.text)
-        }
 
         addClass(WorkbookHeaderStyles.workbookHeader)
         spacing = 10.0
@@ -48,36 +43,35 @@ class WorkbookHeader<T> : VBox() {
             add(
                 JFXCheckBox().apply {
                     isDisableVisualFocus = true
-                    textProperty().bind(filterOptionTextProperty)
-                    managedProperty().bind(filterOptionProperty.isNotNull)
-                    visibleProperty().bind(filterOptionProperty.isNotNull)
-                    action {
-                        if (isSelected) {
-                            // TODO: Tell view model to filter list
-                        } else {
-                            // TODO: Tell view model to remove filter from list
-                        }
-                    }
+                    textProperty().bind(filterTextProperty)
+                    managedProperty().bind(filterTextProperty.isNotNull)
+                    visibleProperty().bind(filterTextProperty.isNotNull)
+                    isFilterOnProperty.bind(selectedProperty())
                 }
             )
         }
         add(
             statusindicator {
                 hgrow = Priority.ALWAYS
-                primaryFillProperty().bind(progressBarTrackFillProperty)
+                primaryFillProperty.bind(progressBarTrackFillProperty)
                 accentFillProperty.bind(progressBarTrackFillProperty)
                 trackFill = Color.LIGHTGRAY
-                prefHeight = 15.0
+                trackHeight = 15.0
                 barHeight = 18.0
                 indicatorRadius = 10.0
-                progressProperty().bind(workbookProgressProperty)
+                progressProperty.bind(workbookProgressProperty)
+                barBorderStyle = BorderStrokeStyle.SOLID
+                barBorderWidth = 1.0
+                barBorderRadius = 10.0
+                textFill = Color.WHITE
+                showText = true
             }
         )
     }
 }
 
-fun <T> workbookheader(init: WorkbookHeader<T>.() -> Unit = {}): WorkbookHeader<T> {
-    val wh = WorkbookHeader<T>()
+fun workbookheader(init: WorkbookHeader.() -> Unit = {}): WorkbookHeader {
+    val wh = WorkbookHeader()
     wh.init()
     return wh
 }

--- a/src/main/kotlin/org/wycliffeassociates/otter/jvm/app/widgets/workbookheader/WorkbookHeaderStyles.kt
+++ b/src/main/kotlin/org/wycliffeassociates/otter/jvm/app/widgets/workbookheader/WorkbookHeaderStyles.kt
@@ -1,0 +1,18 @@
+package org.wycliffeassociates.otter.jvm.app.widgets.workbookheader
+
+import org.wycliffeassociates.otter.jvm.app.theme.AppTheme
+import tornadofx.*
+
+class WorkbookHeaderStyles : Stylesheet() {
+
+    companion object {
+        val workbookHeader by cssclass()
+    }
+
+    init {
+        workbookHeader {
+            padding = box(10.px, 100.px, 20.px, 70.px)
+            backgroundColor += AppTheme.colors.white
+        }
+    }
+}


### PR DESCRIPTION
Header for the upcoming workbook fragment. Includes title, progress bar, and filter checkbox.

The filter checkbox doesn't do anything yet, but you can set a Predicate<T> to be used by the viewmodel (later) to filter the list.

To test, please check out [kj-workbook-header-testapp](https://github.com/WycliffeAssociates/otter-jvm/tree/kj-workbook-header-testapp) and run `main` in **ResourcesCardApp.kt** (this reuses the same test application that I used for the resource cards.)