### PR TITLE
Refactor to remove compiler warnings

### DIFF
--- a/src/main/kotlin/org/wycliffeassociates/otter/jvm/app/ui/menu/viewmodel/MainMenuViewModel.kt
+++ b/src/main/kotlin/org/wycliffeassociates/otter/jvm/app/ui/menu/viewmodel/MainMenuViewModel.kt
@@ -41,7 +41,7 @@ class MainMenuViewModel : ViewModel() {
         showImportDialogProperty.value = true
         importer.import(fileOrDir)
             .observeOnFx()
-            .subscribe { result ->
+            .subscribe { result: ImportResult ->
                 val errorMessage = when (result) {
                     ImportResult.SUCCESS -> null
                     ImportResult.INVALID_RC -> messages["importErrorInvalidRc"]

--- a/src/main/kotlin/org/wycliffeassociates/otter/jvm/app/ui/projectwizard/viewmodel/ProjectWizardViewModel.kt
+++ b/src/main/kotlin/org/wycliffeassociates/otter/jvm/app/ui/projectwizard/viewmodel/ProjectWizardViewModel.kt
@@ -54,7 +54,6 @@ class ProjectWizardViewModel : ViewModel() {
         }
     }
 
-
     private fun filterSourceLanguages() {
         collectionRepo
             .getRootSources()

--- a/src/main/kotlin/org/wycliffeassociates/otter/jvm/app/widgets/SimpleAudioPlayer.kt
+++ b/src/main/kotlin/org/wycliffeassociates/otter/jvm/app/widgets/SimpleAudioPlayer.kt
@@ -86,7 +86,8 @@ fun simpleaudioplayer(
     audioPlayer: IAudioPlayer,
     init: SimpleAudioPlayer.() -> Unit
 ): SimpleAudioPlayer {
-    val audioPlayer = SimpleAudioPlayer(audioFile, audioPlayer)
-    audioPlayer.init()
-    return audioPlayer
+    return SimpleAudioPlayer(audioFile, audioPlayer)
+        .apply {
+            init()
+        }
 }

--- a/src/main/kotlin/org/wycliffeassociates/otter/jvm/app/widgets/card/DefaultStyles.kt
+++ b/src/main/kotlin/org/wycliffeassociates/otter/jvm/app/widgets/card/DefaultStyles.kt
@@ -33,7 +33,7 @@ class DefaultStyles : Stylesheet() {
         val defaultMinorLabel by cssclass()
         val completedProgress by cssclass()
 
-        fun checkCircle(size: String = "1em") = MaterialIconView(MaterialIcon.CHECK_CIRCLE)
+        fun checkCircle(size: String = "1em") = MaterialIconView(MaterialIcon.CHECK_CIRCLE, size)
         fun green() = c("58bd2f")
     }
 

--- a/src/main/kotlin/org/wycliffeassociates/otter/jvm/app/widgets/statusindicator/StatusIndicatorSkin.kt
+++ b/src/main/kotlin/org/wycliffeassociates/otter/jvm/app/widgets/statusindicator/StatusIndicatorSkin.kt
@@ -87,33 +87,30 @@ class StatusIndicatorSkin(control: StatusIndicator) : SkinBase<StatusIndicator>(
 
     fun updateBarFill(primaryFill: Color, accentFill: Color) {
         val stops = listOf(Stop(0.0, primaryFill), Stop(1.0, accentFill))
-        if (bar != null && track != null) {
-            bar.background = Background(
-                BackgroundFill(
-                    LinearGradient(
-                        0.0,
-                        0.0,
-                        0.05,
-                        0.7,
-                        true,
-                        CycleMethod.REPEAT,
-                        stops
-                    ),
-                    CornerRadii(0.0),
-                    Insets(0.0)
-                )
+        bar.background = Background(
+            BackgroundFill(
+                LinearGradient(
+                    0.0,
+                    0.0,
+                    0.05,
+                    0.7,
+                    true,
+                    CycleMethod.REPEAT,
+                    stops
+                ),
+                CornerRadii(0.0),
+                Insets(0.0)
             )
-            skinnable.requestLayout()
-        }
+        )
+        skinnable.requestLayout()
     }
 
+    @Suppress("UNUSED_PARAMETER")
     fun updateStatusIndicator(width: Double, height: Double) {
         val stops = listOf(Stop(0.0, skinPrimaryFill.value), Stop(1.0, skinAccentFill.value))
 
-        if (bar != null && track != null) {
-            children.remove(bar)
-            children.remove(track)
-        }
+        children.remove(bar)
+        children.remove(track)
 
         bar = StackPane()
         bar.border = Border(

--- a/src/main/kotlin/org/wycliffeassociates/otter/jvm/device/audio/AudioPlayer.kt
+++ b/src/main/kotlin/org/wycliffeassociates/otter/jvm/device/audio/AudioPlayer.kt
@@ -22,11 +22,11 @@ class AudioPlayer : IAudioPlayer {
         listeners.add(listener)
     }
 
-    override fun addEventListener(onEventCallback: (event: AudioPlayerEvent) -> Unit) {
+    override fun addEventListener(onEvent: (event: AudioPlayerEvent) -> Unit) {
         listeners.add(
             object : IAudioPlayerListener {
                 override fun onEvent(event: AudioPlayerEvent) {
-                    onEventCallback(event)
+                    onEvent(event)
                 }
             }
         )

--- a/src/main/kotlin/org/wycliffeassociates/otter/jvm/persistence/repositories/AudioPluginRepository.kt
+++ b/src/main/kotlin/org/wycliffeassociates/otter/jvm/persistence/repositories/AudioPluginRepository.kt
@@ -83,15 +83,13 @@ class AudioPluginRepository(
                 audioPluginDao.fetchAll()
             }
             .flatMapCompletable { allPlugins ->
-                if (allPlugins.isEmpty())
-                    return@flatMapCompletable Completable.complete()
-                else {
-                    return@flatMapCompletable preferences.editorPluginId()
+                if (allPlugins.isEmpty()) {
+                    Completable.complete()
+                } else {
+                    preferences.editorPluginId()
                         .flatMapCompletable { editorId ->
                             val editPlugins = allPlugins.filter { it.edit == 1 }
-                            return@flatMapCompletable if (
-                                editorId == AppPreferences.NO_ID && editPlugins.isNotEmpty()
-                            ) {
+                            if (editorId == AppPreferences.NO_ID && editPlugins.isNotEmpty()) {
                                 preferences.setEditorPluginId(editPlugins.first().id)
                             } else {
                                 Completable.complete()
@@ -101,9 +99,9 @@ class AudioPluginRepository(
                         .flatMapCompletable { recorderId ->
                             val recordPlugins = allPlugins.filter { it.record == 1 }
                             if (recorderId == AppPreferences.NO_ID && recordPlugins.isNotEmpty()) {
-                                return@flatMapCompletable preferences.setRecorderPluginId(recordPlugins.first().id)
+                                preferences.setRecorderPluginId(recordPlugins.first().id)
                             } else {
-                                return@flatMapCompletable Completable.complete()
+                                Completable.complete()
                             }
                         }
                 }

--- a/src/main/kotlin/org/wycliffeassociates/otter/jvm/persistence/repositories/LanguageRepository.kt
+++ b/src/main/kotlin/org/wycliffeassociates/otter/jvm/persistence/repositories/LanguageRepository.kt
@@ -1,9 +1,9 @@
 package org.wycliffeassociates.otter.jvm.persistence.repositories
 
-import org.wycliffeassociates.otter.common.data.model.Language
 import io.reactivex.Completable
 import io.reactivex.Single
 import io.reactivex.schedulers.Schedulers
+import org.wycliffeassociates.otter.common.data.model.Language
 import org.wycliffeassociates.otter.common.persistence.repositories.ILanguageRepository
 import org.wycliffeassociates.otter.jvm.persistence.database.AppDatabase
 import org.wycliffeassociates.otter.jvm.persistence.repositories.mapping.LanguageMapper
@@ -14,10 +14,10 @@ class LanguageRepository(
 ) : ILanguageRepository {
     private val languageDao = database.languageDao
 
-    override fun insert(obj: Language): Single<Int> {
+    override fun insert(language: Language): Single<Int> {
         return Single
             .fromCallable {
-                languageDao.insert(mapper.mapToEntity(obj))
+                languageDao.insert(mapper.mapToEntity(language))
             }
             .subscribeOn(Schedulers.io())
     }

--- a/src/main/kotlin/org/wycliffeassociates/otter/jvm/persistence/repositories/ResourceMetadataRepository.kt
+++ b/src/main/kotlin/org/wycliffeassociates/otter/jvm/persistence/repositories/ResourceMetadataRepository.kt
@@ -19,10 +19,10 @@ class ResourceMetadataRepository(
     private val resourceMetadataDao = database.resourceMetadataDao
     private val languageDao = database.languageDao
 
-    override fun insert(obj: ResourceMetadata): Single<Int> {
+    override fun insert(metadata: ResourceMetadata): Single<Int> {
         return Single
             .fromCallable {
-                resourceMetadataDao.insert(metadataMapper.mapToEntity(obj))
+                resourceMetadataDao.insert(metadataMapper.mapToEntity(metadata))
             }
             .subscribeOn(Schedulers.io())
     }

--- a/src/main/kotlin/org/wycliffeassociates/otter/jvm/persistence/repositories/mapping/ContentMapper.kt
+++ b/src/main/kotlin/org/wycliffeassociates/otter/jvm/persistence/repositories/mapping/ContentMapper.kt
@@ -30,7 +30,7 @@ class ContentMapper(private val contentTypeDao: ContentTypeDao) {
             selectedTakeFk = obj.selectedTake?.id,
             text = obj.text,
             format = obj.format,
-            type_fk = contentTypeDao.fetchId(obj.type)!!
+            type_fk = contentTypeDao.fetchId(obj.type)
         )
     }
 }

--- a/src/main/kotlin/org/wycliffeassociates/otter/jvm/recorder/app/view/drawables/WaveformLayer.kt
+++ b/src/main/kotlin/org/wycliffeassociates/otter/jvm/recorder/app/view/drawables/WaveformLayer.kt
@@ -9,15 +9,15 @@ private const val USHORT_SIZE = 65535.0
 
 class WaveformLayer(private val renderer: ActiveRecordingRenderer) : Drawable {
 
-    override fun draw(gc: GraphicsContext, canvas: Canvas) {
-        gc.stroke = Color.GRAY
-        gc.lineWidth = 1.0
+    override fun draw(context: GraphicsContext, canvas: Canvas) {
+        context.stroke = Color.GRAY
+        context.lineWidth = 1.0
 
         val buffer = renderer.floatBuffer.array
         var i = 0
         var x = 0.0
         while (i < buffer.size) {
-            gc.strokeLine(
+            context.strokeLine(
                 x,
                 scaleAmplitude(buffer[i].toDouble(), canvas.height),
                 x,


### PR DESCRIPTION
Fix Kotlin compiler warnings:

- Unnecessary null-safe `?.` calls
- Always-true or -false conditional predicates
- Java enum interop warnings (can be nullable)
- Unused parameters
- Variable name shadowing
- Deprecated API use
- Ambiguous `return@` targets
- Overridden methods with differently named parameters
- More?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wycliffeassociates/otter-jvm/465)
<!-- Reviewable:end -->
