### PR TITLE
Add local.properties to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,7 @@ fabric.properties
 #Covers Gradle
 .gradle
 /build/
+local.properties
 
 # Ignore Gradle GUI config
 gradle-org.wycliffeassociates.otter.jvm.app.setting


### PR DESCRIPTION
IDEA or Gradle has recently been adding this file to my project.  Its contents look like this:
```
  # This file must *NOT* be checked into Version Control Systems,
  # as it contains information specific to your local configuration.
  #
  # Location of the SDK. This is only used by Gradle.
  # For customization when using a Version Control System, please read the
  # header note.
  #Thu Aug 08 21:53:19 EDT 2019
  sdk.dir=C\:\\AndroidSDK
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wycliffeassociates/otter-jvm/472)
<!-- Reviewable:end -->
