### PR TITLE
Takes Page Fixes

### DIFF
--- a/src/main/kotlin/org/wycliffeassociates/otter/jvm/app/ui/mainscreen/viewmodel/MainScreenViewModel.kt
+++ b/src/main/kotlin/org/wycliffeassociates/otter/jvm/app/ui/mainscreen/viewmodel/MainScreenViewModel.kt
@@ -7,6 +7,7 @@ import org.wycliffeassociates.otter.common.data.workbook.Chunk
 import org.wycliffeassociates.otter.common.data.workbook.Workbook
 import org.wycliffeassociates.otter.jvm.app.ui.mainscreen.view.MainScreenView
 import org.wycliffeassociates.otter.jvm.app.ui.cardgrid.view.CardGridFragment
+import org.wycliffeassociates.otter.jvm.app.ui.projectwizard.view.SlugsEnum
 import org.wycliffeassociates.otter.jvm.app.ui.takemanagement.view.RecordScriptureFragment
 import org.wycliffeassociates.otter.jvm.app.ui.workbook.viewmodel.WorkbookViewModel
 import tornadofx.*
@@ -50,6 +51,7 @@ class MainScreenViewModel : ViewModel() {
     private fun chunkSelected(chunk: Chunk) {
         setActiveChunkText(chunk)
 
+        workbookViewModel.activeResourceSlugProperty.set(SlugsEnum.ULB.slug)
         find<MainScreenView>().activeFragment.dock<RecordScriptureFragment>()
     }
 

--- a/src/main/kotlin/org/wycliffeassociates/otter/jvm/app/ui/projectgrid/viewmodel/ProjectGridViewModel.kt
+++ b/src/main/kotlin/org/wycliffeassociates/otter/jvm/app/ui/projectgrid/viewmodel/ProjectGridViewModel.kt
@@ -64,8 +64,7 @@ class ProjectGridViewModel : ViewModel() {
         val projectAudioDir = directoryProvider.getProjectAudioDirectory(
             sourceMetadata = sourceProject.resourceContainer ?:
                 throw RuntimeException("No source metadata found."),
-            book = targetProject,
-            chapterDirName = targetProject.titleKey // TODO: What???
+            book = targetProject
         )
         workbookViewModel.activeProjectAudioDirectoryProperty.set(projectAudioDir)
     }

--- a/src/main/kotlin/org/wycliffeassociates/otter/jvm/app/ui/projectgrid/viewmodel/ProjectGridViewModel.kt
+++ b/src/main/kotlin/org/wycliffeassociates/otter/jvm/app/ui/projectgrid/viewmodel/ProjectGridViewModel.kt
@@ -16,6 +16,7 @@ class ProjectGridViewModel : ViewModel() {
     private val injector: Injector by inject()
     private val collectionRepo = injector.collectionRepo
     private val workbookRepo = injector.workbookRepository
+    private val directoryProvider = injector.directoryProvider
 
     private val workbookViewModel: WorkbookViewModel by inject()
 
@@ -51,9 +52,21 @@ class ProjectGridViewModel : ViewModel() {
     fun selectProject(targetProject: Collection) {
         collectionRepo.getSource(targetProject)
             .observeOnFx()
-            .subscribe {
-                val workbook = workbookRepo.get(it, targetProject)
+            .subscribe { sourceProject ->
+                val workbook = workbookRepo.get(sourceProject, targetProject)
                 workbookViewModel.activeWorkbookProperty.set(workbook)
+
+                setProjectAudioDirectory(targetProject, sourceProject)
             }
+    }
+
+    private fun setProjectAudioDirectory(targetProject: Collection, sourceProject: Collection) {
+        val projectAudioDir = directoryProvider.getProjectAudioDirectory(
+            sourceMetadata = sourceProject.resourceContainer ?:
+                throw RuntimeException("No source metadata found."),
+            book = targetProject,
+            chapterDirName = targetProject.titleKey // TODO: What???
+        )
+        workbookViewModel.activeProjectAudioDirectoryProperty.set(projectAudioDir)
     }
 }

--- a/src/main/kotlin/org/wycliffeassociates/otter/jvm/app/ui/resourcetakes/view/RecordResourceFragment.kt
+++ b/src/main/kotlin/org/wycliffeassociates/otter/jvm/app/ui/resourcetakes/view/RecordResourceFragment.kt
@@ -43,7 +43,15 @@ class RecordResourceFragment(
     private val leftRegion = VBox().apply {
         vgrow = Priority.ALWAYS
 
-        add(dragTarget)
+        hbox {
+            region {
+                hgrow = Priority.ALWAYS
+            }
+            add(dragTarget)
+            region {
+                hgrow = Priority.ALWAYS
+            }
+        }
 
         scrollpane {
             addClass(RecordResourceStyles.contentScrollPane)

--- a/src/main/kotlin/org/wycliffeassociates/otter/jvm/app/ui/takemanagement/view/RecordScriptureFragment.kt
+++ b/src/main/kotlin/org/wycliffeassociates/otter/jvm/app/ui/takemanagement/view/RecordScriptureFragment.kt
@@ -42,7 +42,15 @@ class RecordScriptureFragment : RecordableFragment(
                     }
                     enableWhen(recordScriptureViewModel.hasPrevious)
                 }
-                add(dragTarget)
+                vbox {
+                    region {
+                        vgrow = Priority.ALWAYS
+                    }
+                    add(dragTarget)
+                    region {
+                        vgrow = Priority.ALWAYS
+                    }
+                }
 
                 //next verse button
                 button(messages["nextVerse"], AppStyles.forwardIcon()) {

--- a/src/main/kotlin/org/wycliffeassociates/otter/jvm/app/ui/takemanagement/viewmodel/RecordableViewModel.kt
+++ b/src/main/kotlin/org/wycliffeassociates/otter/jvm/app/ui/takemanagement/viewmodel/RecordableViewModel.kt
@@ -101,13 +101,19 @@ open class RecordableViewModel(
     private fun Take.isNotDeleted() = deletedTimestamp.value?.value == null
 
     private fun loadTakes(audio: AssociatedAudio) {
-        alternateTakes.clear()
         // selectedTakeProperty may not have been updated yet so ask for the current selected take
         val selected = audio.selected.value?.value
+
+        val loadedAlternateTakes =
+            audio.getAllTakes()
+                .filter { it.isNotDeleted() }
+                .filter { it != selected }
+        alternateTakes.setAll(loadedAlternateTakes)
+
         audio.takes
             .filter { it.isNotDeleted() }
             .subscribe {
-                if (it != selected) {
+                if (it != selected && !alternateTakes.contains(it)) {
                     addToAlternateTakes(it)
                 }
                 removeOnDeleted(it)

--- a/src/main/kotlin/org/wycliffeassociates/otter/jvm/app/ui/workbook/viewmodel/WorkbookViewModel.kt
+++ b/src/main/kotlin/org/wycliffeassociates/otter/jvm/app/ui/workbook/viewmodel/WorkbookViewModel.kt
@@ -5,15 +5,11 @@ import javafx.beans.property.SimpleStringProperty
 import org.wycliffeassociates.otter.common.data.workbook.Chapter
 import org.wycliffeassociates.otter.common.data.workbook.Chunk
 import org.wycliffeassociates.otter.common.data.workbook.Workbook
-import org.wycliffeassociates.otter.jvm.app.ui.inject.Injector
 import tornadofx.*
 import java.io.File
 import java.lang.IllegalStateException
 
 class WorkbookViewModel: ViewModel() {
-    private val injector: Injector by inject()
-    private val directoryProvider = injector.directoryProvider
-
     val activeWorkbookProperty = SimpleObjectProperty<Workbook>()
     val workbook: Workbook
         get() = activeWorkbookProperty.value ?: throw IllegalStateException("Workbook is null")
@@ -36,22 +32,4 @@ class WorkbookViewModel: ViewModel() {
     val projectAudioDirectory: File
         get() = activeProjectAudioDirectoryProperty.value
             ?: throw IllegalStateException("Project audio directory is null")
-
-    init {
-        activeWorkbookProperty.onChange { workbook ->
-            workbook?.let {
-                activeProjectAudioDirectoryProperty.set(getProjectAudioDirectory(workbook))
-            }
-        }
-    }
-
-    private fun getProjectAudioDirectory(workbook: Workbook): File {
-        val path = directoryProvider.getUserDataDirectory(
-            "testAudioPath\\" +
-                    "${workbook.target.language.slug}\\" +
-                    "${workbook.target.slug}\\"
-        )
-        path.mkdirs()
-        return path
-    }
 }

--- a/src/main/kotlin/org/wycliffeassociates/otter/jvm/app/ui/workbook/viewmodel/WorkbookViewModel.kt
+++ b/src/main/kotlin/org/wycliffeassociates/otter/jvm/app/ui/workbook/viewmodel/WorkbookViewModel.kt
@@ -5,11 +5,15 @@ import javafx.beans.property.SimpleStringProperty
 import org.wycliffeassociates.otter.common.data.workbook.Chapter
 import org.wycliffeassociates.otter.common.data.workbook.Chunk
 import org.wycliffeassociates.otter.common.data.workbook.Workbook
+import org.wycliffeassociates.otter.jvm.app.ui.inject.Injector
 import tornadofx.*
 import java.io.File
 import java.lang.IllegalStateException
 
 class WorkbookViewModel: ViewModel() {
+    private val injector: Injector by inject()
+    private val directoryProvider = injector.directoryProvider
+
     val activeWorkbookProperty = SimpleObjectProperty<Workbook>()
     val workbook: Workbook
         get() = activeWorkbookProperty.value ?: throw IllegalStateException("Workbook is null")
@@ -32,4 +36,22 @@ class WorkbookViewModel: ViewModel() {
     val projectAudioDirectory: File
         get() = activeProjectAudioDirectoryProperty.value
             ?: throw IllegalStateException("Project audio directory is null")
+
+    init {
+        activeWorkbookProperty.onChange { workbook ->
+            workbook?.let {
+                activeProjectAudioDirectoryProperty.set(getProjectAudioDirectory(workbook))
+            }
+        }
+    }
+
+    private fun getProjectAudioDirectory(workbook: Workbook): File {
+        val path = directoryProvider.getUserDataDirectory(
+            "testAudioPath\\" +
+                    "${workbook.target.language.slug}\\" +
+                    "${workbook.target.slug}\\"
+        )
+        path.mkdirs()
+        return path
+    }
 }

--- a/src/main/kotlin/org/wycliffeassociates/otter/jvm/app/widgets/takecard/TakeCardSkin.kt
+++ b/src/main/kotlin/org/wycliffeassociates/otter/jvm/app/widgets/takecard/TakeCardSkin.kt
@@ -70,7 +70,6 @@ abstract class TakeCardSkin(control: TakeCard) : SkinBase<TakeCard>(control) {
     private fun completeDrag(evt: MouseEvent) {
         skinnable.fireEvent(
             CompleteDragEvent(
-                evt,
                 skinnable.take,
                 ::onCancelDrag
             )

--- a/src/main/kotlin/org/wycliffeassociates/otter/jvm/app/widgets/takecard/events/CompleteDragEvent.kt
+++ b/src/main/kotlin/org/wycliffeassociates/otter/jvm/app/widgets/takecard/events/CompleteDragEvent.kt
@@ -2,11 +2,9 @@ package org.wycliffeassociates.otter.jvm.app.widgets.takecard.events
 
 import javafx.event.Event
 import javafx.event.EventType
-import javafx.scene.input.MouseEvent
 import org.wycliffeassociates.otter.common.data.workbook.Take
 
 class CompleteDragEvent(
-    val mouseEvent: MouseEvent,
     val take: Take,
     val onCancel: () -> Unit
 ): Event(COMPLETE_DRAG) {

--- a/src/main/kotlin/org/wycliffeassociates/otter/jvm/persistence/DirectoryProvider.kt
+++ b/src/main/kotlin/org/wycliffeassociates/otter/jvm/persistence/DirectoryProvider.kt
@@ -61,8 +61,7 @@ class DirectoryProvider(
 
     override fun getProjectAudioDirectory(
         sourceMetadata: ResourceMetadata,
-        book: Collection,
-        chapterDirName: String
+        book: Collection
     ): File {
         val appendedPath = listOf(
             book.resourceContainer?.creator ?: ".",
@@ -70,8 +69,7 @@ class DirectoryProvider(
             "${sourceMetadata.language.slug}_${sourceMetadata.identifier}",
             "v${book.resourceContainer?.version ?: "-none"}",
             book.resourceContainer?.language?.slug ?: "no_language",
-            book.slug,
-            chapterDirName
+            book.slug
         ).joinToString(pathSeparator)
         val path = getUserDataDirectory(appendedPath)
         path.mkdirs()

--- a/src/main/kotlin/org/wycliffeassociates/otter/jvm/persistence/repositories/CollectionRepository.kt
+++ b/src/main/kotlin/org/wycliffeassociates/otter/jvm/persistence/repositories/CollectionRepository.kt
@@ -78,7 +78,7 @@ class CollectionRepository(
                             if (deleteAudio) {
                                 val audioDirectory = directoryProvider.getProjectAudioDirectory(
                                         it.resourceContainer ?: throw RuntimeException("No source metadata found."),
-                                        project, ".").parentFile
+                                        project).parentFile
                                 audioDirectory.deleteRecursively()
                             }
                         }.ignoreElement()

--- a/src/main/kotlin/org/wycliffeassociates/otter/jvm/persistence/repositories/CollectionRepository.kt
+++ b/src/main/kotlin/org/wycliffeassociates/otter/jvm/persistence/repositories/CollectionRepository.kt
@@ -31,11 +31,11 @@ import java.time.LocalDate
 
 
 class CollectionRepository(
-        private val database: AppDatabase,
-        private val directoryProvider: IDirectoryProvider,
-        private val collectionMapper: CollectionMapper = CollectionMapper(),
-        private val metadataMapper: ResourceMetadataMapper = ResourceMetadataMapper(),
-        private val languageMapper: LanguageMapper = LanguageMapper()
+    private val database: AppDatabase,
+    private val directoryProvider: IDirectoryProvider,
+    private val collectionMapper: CollectionMapper = CollectionMapper(),
+    private val metadataMapper: ResourceMetadataMapper = ResourceMetadataMapper(),
+    private val languageMapper: LanguageMapper = LanguageMapper()
 ) : ICollectionRepository {
 
     private val collectionDao = database.collectionDao
@@ -44,147 +44,152 @@ class CollectionRepository(
 
     override fun delete(obj: Collection): Completable {
         return Completable
-                .fromAction {
-                    collectionDao.delete(collectionMapper.mapToEntity(obj))
-                }
-                .subscribeOn(Schedulers.io())
+            .fromAction {
+                collectionDao.delete(collectionMapper.mapToEntity(obj))
+            }
+            .subscribeOn(Schedulers.io())
     }
 
     override fun deleteProject(project: Collection, deleteAudio: Boolean): Completable {
         return Completable
-                .fromAction {
-                    // 1. Delete the project collection from the database. The associated chunks, takes, and links
-                    //    should be cascade deleted
-                    collectionDao.delete(collectionMapper.mapToEntity(project))
-                    // 2. Load the resource container
-                    val metadata = project.resourceContainer
-                    if (metadata != null) {
-                        ResourceContainer.load(metadata.path).use { container ->
-                            // 3. Remove the project from the manifest
-                            container.manifest.projects = container.manifest.projects.filter { it.identifier != project.slug }
-                            // 4a. If the manifest has more projects, write out the new manifest
-                            if (container.manifest.projects.isNotEmpty()) {
-                                container.writeManifest()
-                            } else {
-                                // 4b. If the manifest has no projects left, delete the RC folder and the metadata from the database
-                                metadata.path.deleteRecursively()
-                                metadataDao.delete(metadataMapper.mapToEntity(metadata))
-                            }
+            .fromAction {
+                // 1. Delete the project collection from the database. The associated chunks, takes, and links
+                //    should be cascade deleted
+                collectionDao.delete(collectionMapper.mapToEntity(project))
+                // 2. Load the resource container
+                val metadata = project.resourceContainer
+                if (metadata != null) {
+                    ResourceContainer.load(metadata.path).use { container ->
+                        // 3. Remove the project from the manifest
+                        container.manifest.projects = container
+                            .manifest
+                            .projects
+                            .filter { it.identifier != project.slug }
+                        // 4a. If the manifest has more projects, write out the new manifest
+                        if (container.manifest.projects.isNotEmpty()) {
+                            container.writeManifest()
+                        } else {
+                            // 4b. If the manifest has no projects left,
+                            // delete the RC folder and the metadata from the database
+                            metadata.path.deleteRecursively()
+                            metadataDao.delete(metadataMapper.mapToEntity(metadata))
                         }
                     }
-                }.andThen(
-                        getSource(project).doOnSuccess {
-                            // If project audio should be deleted, get the folder for the project audio and delete it
-                            if (deleteAudio) {
-                                val audioDirectory = directoryProvider.getProjectAudioDirectory(
-                                        it.resourceContainer ?: throw RuntimeException("No source metadata found."),
-                                        project)
-                                audioDirectory.deleteRecursively()
-                            }
-                        }.ignoreElement()
-                )
-                .subscribeOn(Schedulers.io())
+                }
+            }.andThen(
+                getSource(project).doOnSuccess {
+                    // If project audio should be deleted, get the folder for the project audio and delete it
+                    if (deleteAudio) {
+                        val audioDirectory = directoryProvider.getProjectAudioDirectory(
+                            it.resourceContainer ?: throw RuntimeException("No source metadata found."),
+                            project
+                        )
+                        audioDirectory.deleteRecursively()
+                    }
+                }.ignoreElement()
+            )
+            .subscribeOn(Schedulers.io())
     }
 
     override fun getAll(): Single<List<Collection>> {
         return Single
-                .fromCallable {
-                    collectionDao
-                            .fetchAll()
-                            .map(this::buildCollection)
-                }
-                .subscribeOn(Schedulers.io())
+            .fromCallable {
+                collectionDao
+                    .fetchAll()
+                    .map(this::buildCollection)
+            }
+            .subscribeOn(Schedulers.io())
     }
 
     override fun getRootProjects(): Single<List<Collection>> {
         return Single
-                .fromCallable {
-                    collectionDao
-                            .fetchAll()
-                            .filter { it.sourceFk != null && it.label == "project" }
-                            .map(this::buildCollection)
-                }
-                .subscribeOn(Schedulers.io())
+            .fromCallable {
+                collectionDao
+                    .fetchAll()
+                    .filter { it.sourceFk != null && it.label == "project" }
+                    .map(this::buildCollection)
+            }
+            .subscribeOn(Schedulers.io())
     }
 
     override fun getRootSources(): Single<List<Collection>> {
         return Single
-                .fromCallable {
-                    collectionDao
-                            .fetchAll()
-                            .filter { it.parentFk == null && it.sourceFk == null }
-                            .map(this::buildCollection)
-                }
-                .subscribeOn(Schedulers.io())
+            .fromCallable {
+                collectionDao
+                    .fetchAll()
+                    .filter { it.parentFk == null && it.sourceFk == null }
+                    .map(this::buildCollection)
+            }
+            .subscribeOn(Schedulers.io())
     }
 
     override fun getSource(project: Collection): Maybe<Collection> {
         return Maybe
-                .fromCallable {
-                    buildCollection(
-                            collectionDao.fetchSource(collectionDao.fetchById(project.id))
-                    )
-                }
-                .onErrorComplete()
-                .subscribeOn(Schedulers.io())
+            .fromCallable {
+                buildCollection(
+                    collectionDao.fetchSource(collectionDao.fetchById(project.id))
+                )
+            }
+            .onErrorComplete()
+            .subscribeOn(Schedulers.io())
     }
 
     override fun getBySlugAndContainer(slug: String, container: ResourceMetadata): Maybe<Collection> {
         return Maybe
-                .fromCallable {
-                    collectionDao.fetchBySlugAndContainerId(slug, container.id)
-                }
-                .map(this::buildCollection)
-                .onErrorComplete()
-                .subscribeOn(Schedulers.io())
+            .fromCallable {
+                collectionDao.fetchBySlugAndContainerId(slug, container.id)
+            }
+            .map(this::buildCollection)
+            .onErrorComplete()
+            .subscribeOn(Schedulers.io())
     }
 
     override fun getChildren(collection: Collection): Single<List<Collection>> {
         return Single
-                .fromCallable {
-                    collectionDao
-                            .fetchChildren(collectionMapper.mapToEntity(collection))
-                            .map(this::buildCollection)
-                }
-                .subscribeOn(Schedulers.io())
+            .fromCallable {
+                collectionDao
+                    .fetchChildren(collectionMapper.mapToEntity(collection))
+                    .map(this::buildCollection)
+            }
+            .subscribeOn(Schedulers.io())
     }
 
     override fun updateSource(collection: Collection, newSource: Collection): Completable {
         return Completable
-                .fromAction {
-                    val entity = collectionDao.fetchById(collection.id)
-                    entity.sourceFk = newSource.id
-                    collectionDao.update(entity)
-                }
-                .subscribeOn(Schedulers.io())
+            .fromAction {
+                val entity = collectionDao.fetchById(collection.id)
+                entity.sourceFk = newSource.id
+                collectionDao.update(entity)
+            }
+            .subscribeOn(Schedulers.io())
     }
 
     override fun updateParent(collection: Collection, newParent: Collection): Completable {
         return Completable
-                .fromAction {
-                    val entity = collectionDao.fetchById(collection.id)
-                    entity.parentFk = newParent.id
-                    collectionDao.update(entity)
-                }
-                .subscribeOn(Schedulers.io())
+            .fromAction {
+                val entity = collectionDao.fetchById(collection.id)
+                entity.parentFk = newParent.id
+                collectionDao.update(entity)
+            }
+            .subscribeOn(Schedulers.io())
     }
 
     override fun insert(collection: Collection): Single<Int> {
         return Single
-                .fromCallable {
-                    collectionDao.insert(collectionMapper.mapToEntity(collection))
-                }
-                .subscribeOn(Schedulers.io())
+            .fromCallable {
+                collectionDao.insert(collectionMapper.mapToEntity(collection))
+            }
+            .subscribeOn(Schedulers.io())
     }
 
     override fun update(obj: Collection): Completable {
         return Completable
-                .fromAction {
-                    val entity = collectionDao.fetchById(obj.id)
-                    val newEntity = collectionMapper.mapToEntity(obj, entity.parentFk, entity.sourceFk)
-                    collectionDao.update(newEntity)
-                }
-                .subscribeOn(Schedulers.io())
+            .fromAction {
+                val entity = collectionDao.fetchById(obj.id)
+                val newEntity = collectionMapper.mapToEntity(obj, entity.parentFk, entity.sourceFk)
+                collectionDao.update(newEntity)
+            }
+            .subscribeOn(Schedulers.io())
     }
 
     private fun createResourceContainer(source: Collection, targetLanguage: Language): ResourceContainer {
@@ -208,19 +213,18 @@ class CollectionRepository(
             title = metadata.title
         }
         val directory = directoryProvider.getDerivedContainerDirectory(
-                // A placeholder file is needed here for the mapping function
-                // The file is never used, since the DP doesn't look at the directory
-                // to generate the derived directory.
-                dublinCore.mapToMetadata(File("."), targetLanguage),
-                metadata
+            // A placeholder file is needed here for the mapping function
+            // The file is never used, since the DP doesn't look at the directory
+            // to generate the derived directory.
+            dublinCore.mapToMetadata(File("."), targetLanguage),
+            metadata
         )
-        // TODO 2/14/19: Move create to ResourceContainer to be able to create a zip resource container?
         val container = ResourceContainer.create(directory) {
             // Set up the manifest
             manifest = Manifest(
-                    dublinCore,
-                    listOf(),
-                    Checking()
+                dublinCore,
+                listOf(),
+                Checking()
             )
         }
         container.write()
@@ -229,210 +233,219 @@ class CollectionRepository(
 
     override fun deriveProject(source: Collection, language: Language): Completable {
         return Completable
-                .fromAction {
-                    database.transaction { dsl ->
-                        // Check for existing resource containers
-                        val existingMetadata = metadataDao.fetchAll(dsl)
-                        val matches = existingMetadata.filter {
-                            it.identifier == source.resourceContainer?.identifier
-                                    && it.languageFk == language.id
-                                    && it.creator == "otter"
-                                    && it.version == source.resourceContainer?.version
-                                    && it.derivedFromFk == source.resourceContainer?.id
+            .fromAction {
+                database.transaction { dsl ->
+                    // Check for existing resource containers
+                    val existingMetadata = metadataDao.fetchAll(dsl)
+                    val matches = existingMetadata.filter {
+                        it.identifier == source.resourceContainer?.identifier
+                            && it.languageFk == language.id
+                            && it.creator == "otter"
+                            && it.version == source.resourceContainer?.version
+                            && it.derivedFromFk == source.resourceContainer?.id
+                    }
+
+                    val metadataEntity = if (matches.isEmpty()) {
+                        // This combination of identifier and language does not already exist; create it
+                        createResourceContainer(source, language).use { container ->
+                            // Convert DublinCore to ResourceMetadata
+                            val metadata = container.manifest.dublinCore
+                                .mapToMetadata(container.file, language)
+
+                            // Insert ResourceMetadata into database
+                            val entity = metadataMapper.mapToEntity(metadata)
+                            entity.derivedFromFk = source.resourceContainer?.id
+                            entity.id = metadataDao.insert(entity, dsl)
+                            /* return@if */ entity
                         }
+                    } else {
+                        // Use the existing metadata
+                        /* return@if */ matches.first()
+                    }
 
-                        val metadataEntity = if (matches.isEmpty()) {
-                            // This combination of identifier and language does not already exist; create it
-                            createResourceContainer(source, language).use { container ->
-                                // Convert DublinCore to ResourceMetadata
-                                val metadata = container.manifest.dublinCore
-                                        .mapToMetadata(container.file, language)
+                    // Insert the derived project
+                    val sourceEntity = collectionDao.fetchById(source.id, dsl)
+                    val projectEntity = sourceEntity
+                        // parentFk null for now. May be non-null if derivative categories added
+                        .copy(id = 0, dublinCoreFk = metadataEntity.id, parentFk = null, sourceFk = sourceEntity.id)
+                    projectEntity.id = collectionDao.insert(projectEntity, dsl)
 
-                                // Insert ResourceMetadata into database
-                                val entity = metadataMapper.mapToEntity(metadata)
-                                entity.derivedFromFk = source.resourceContainer?.id
-                                entity.id = metadataDao.insert(entity, dsl)
-                                /* return@if */ entity
-                            }
-                        } else {
-                            // Use the existing metadata
-                            /* return@if */ matches.first()
-                        }
+                    // Copy the chapters
+                    copyChapters(dsl, sourceEntity.id, projectEntity.id, metadataEntity.id)
 
-                        // Insert the derived project
-                        val sourceEntity = collectionDao.fetchById(source.id, dsl)
-                        val projectEntity = sourceEntity
-                                // parentFk null for now. May be non-null if derivative categories added
-                                .copy(id = 0, dublinCoreFk = metadataEntity.id, parentFk = null, sourceFk = sourceEntity.id)
-                        projectEntity.id = collectionDao.insert(projectEntity, dsl)
+                    // Copy the content
+                    copyContent(dsl, sourceEntity.id, metadataEntity.id)
 
-                        // Copy the chapters
-                        copyChapters(dsl, sourceEntity.id, projectEntity.id, metadataEntity.id)
+                    // Link the derivative content
+                    linkContent(dsl, sourceEntity.id, projectEntity.id)
 
-                        // Copy the content
-                        copyContent(dsl, sourceEntity.id, metadataEntity.id)
-
-                        // Link the derivative content
-                        linkContent(dsl, sourceEntity.id, projectEntity.id)
-
-                        // Add a project to the container if necessary
-                        // Load the existing resource container and see if we need to add another project
-                        ResourceContainer.load(File(metadataEntity.path)).use { container ->
-                            if (container.manifest.projects.none { it.identifier == source.slug }) {
-                                container.manifest.projects = container.manifest.projects.plus(
-                                        project {
-                                            sort = if (metadataEntity.subject.toLowerCase() == "bible"
-                                                    && projectEntity.sort > 39) {
-                                                projectEntity.sort + 1
-                                            } else {
-                                                projectEntity.sort
-                                            }
-                                            identifier = projectEntity.slug
-                                            path = "./${projectEntity.slug}"
-                                            // This title will not be localized into the target language
-                                            title = projectEntity.title
-                                            // Unable to get categories and versification from the source collection
-                                        }
-                                )
-                                // Update the container
-                                container.write()
-                            }
+                    // Add a project to the container if necessary
+                    // Load the existing resource container and see if we need to add another project
+                    ResourceContainer.load(File(metadataEntity.path)).use { container ->
+                        if (container.manifest.projects.none { it.identifier == source.slug }) {
+                            container.manifest.projects = container.manifest.projects.plus(
+                                project {
+                                    sort = if (metadataEntity.subject.toLowerCase() == "bible"
+                                        && projectEntity.sort > 39
+                                    ) {
+                                        projectEntity.sort + 1
+                                    } else {
+                                        projectEntity.sort
+                                    }
+                                    identifier = projectEntity.slug
+                                    path = "./${projectEntity.slug}"
+                                    // This title will not be localized into the target language
+                                    title = projectEntity.title
+                                    // Unable to get categories and versification from the source collection
+                                }
+                            )
+                            // Update the container
+                            container.write()
                         }
                     }
                 }
-                .subscribeOn(Schedulers.io())
+            }
+            .subscribeOn(Schedulers.io())
     }
 
     private fun copyChapters(dsl: DSLContext, sourceId: Int, projectId: Int, metadataId: Int) {
         // Copy all the chapter collections
         dsl.insertInto(
-                COLLECTION_ENTITY,
-                COLLECTION_ENTITY.PARENT_FK,
-                COLLECTION_ENTITY.SOURCE_FK,
+            COLLECTION_ENTITY,
+            COLLECTION_ENTITY.PARENT_FK,
+            COLLECTION_ENTITY.SOURCE_FK,
+            COLLECTION_ENTITY.LABEL,
+            COLLECTION_ENTITY.TITLE,
+            COLLECTION_ENTITY.SLUG,
+            COLLECTION_ENTITY.SORT,
+            COLLECTION_ENTITY.DUBLIN_CORE_FK
+        ).select(
+            dsl.select(
+                value(projectId),
+                COLLECTION_ENTITY.ID,
                 COLLECTION_ENTITY.LABEL,
                 COLLECTION_ENTITY.TITLE,
                 COLLECTION_ENTITY.SLUG,
                 COLLECTION_ENTITY.SORT,
-                COLLECTION_ENTITY.DUBLIN_CORE_FK
-        ).select(
-                dsl.select(
-                        value(projectId),
-                        COLLECTION_ENTITY.ID,
-                        COLLECTION_ENTITY.LABEL,
-                        COLLECTION_ENTITY.TITLE,
-                        COLLECTION_ENTITY.SLUG,
-                        COLLECTION_ENTITY.SORT,
-                        value(metadataId)
-                )
-                        .from(COLLECTION_ENTITY)
-                        .where(COLLECTION_ENTITY.PARENT_FK.eq(sourceId))
+                value(metadataId)
+            )
+                .from(COLLECTION_ENTITY)
+                .where(COLLECTION_ENTITY.PARENT_FK.eq(sourceId))
         ).execute()
     }
 
     private fun copyContent(dsl: DSLContext, sourceId: Int, metadataId: Int) {
         dsl.insertInto(
-                CONTENT_ENTITY,
-                CONTENT_ENTITY.COLLECTION_FK,
-                CONTENT_ENTITY.LABEL,
-                CONTENT_ENTITY.START,
-                CONTENT_ENTITY.SORT,
-                CONTENT_ENTITY.TYPE_FK
+            CONTENT_ENTITY,
+            CONTENT_ENTITY.COLLECTION_FK,
+            CONTENT_ENTITY.LABEL,
+            CONTENT_ENTITY.START,
+            CONTENT_ENTITY.SORT,
+            CONTENT_ENTITY.TYPE_FK
         )
-                .select(
+            .select(
+                dsl.select(
+                    COLLECTION_ENTITY.ID,
+                    field("verselabel", String::class.java),
+                    field("versestart", Int::class.java),
+                    field("versesort", Int::class.java),
+                    field("typefk", Int::class.java)
+                )
+                    .from(
                         dsl.select(
-                                COLLECTION_ENTITY.ID,
-                                field("verselabel", String::class.java),
-                                field("versestart", Int::class.java),
-                                field("versesort", Int::class.java),
-                                field("typefk", Int::class.java)
+                            CONTENT_ENTITY.ID.`as`("verseid"),
+                            CONTENT_ENTITY.COLLECTION_FK.`as`("chapterid"),
+                            CONTENT_ENTITY.LABEL.`as`("verselabel"),
+                            CONTENT_ENTITY.START.`as`("versestart"),
+                            CONTENT_ENTITY.SORT.`as`("versesort"),
+                            CONTENT_ENTITY.TYPE_FK.`as`("typefk")
                         )
-                                .from(
-                                        dsl.select(
-                                                CONTENT_ENTITY.ID.`as`("verseid"),
-                                                CONTENT_ENTITY.COLLECTION_FK.`as`("chapterid"),
-                                                CONTENT_ENTITY.LABEL.`as`("verselabel"),
-                                                CONTENT_ENTITY.START.`as`("versestart"),
-                                                CONTENT_ENTITY.SORT.`as`("versesort"),
-                                                CONTENT_ENTITY.TYPE_FK.`as`("typefk")
-                                        )
-                                                .from(CONTENT_ENTITY)
-                                                .where(CONTENT_ENTITY.COLLECTION_FK.`in`(
-                                                        dsl
-                                                                .select(COLLECTION_ENTITY.ID)
-                                                                .from(COLLECTION_ENTITY)
-                                                                .where(COLLECTION_ENTITY.PARENT_FK.eq(sourceId))
-                                                ))
+                            .from(CONTENT_ENTITY)
+                            .where(
+                                CONTENT_ENTITY.COLLECTION_FK.`in`(
+                                    dsl
+                                        .select(COLLECTION_ENTITY.ID)
+                                        .from(COLLECTION_ENTITY)
+                                        .where(COLLECTION_ENTITY.PARENT_FK.eq(sourceId))
                                 )
-                                .leftJoin(COLLECTION_ENTITY)
-                                .on(COLLECTION_ENTITY.SOURCE_FK.eq(field("chapterid", Int::class.java))
-                                        .and(COLLECTION_ENTITY.DUBLIN_CORE_FK.eq(metadataId)))
-                ).execute()
+                            )
+                    )
+                    .leftJoin(COLLECTION_ENTITY)
+                    .on(
+                        COLLECTION_ENTITY.SOURCE_FK.eq(field("chapterid", Int::class.java))
+                            .and(COLLECTION_ENTITY.DUBLIN_CORE_FK.eq(metadataId))
+                    )
+            ).execute()
     }
 
     private fun linkContent(dsl: DSLContext, sourceId: Int, projectId: Int) {
         dsl.insertInto(
-                CONTENT_DERIVATIVE,
-                CONTENT_DERIVATIVE.CONTENT_FK,
-                CONTENT_DERIVATIVE.SOURCE_FK
+            CONTENT_DERIVATIVE,
+            CONTENT_DERIVATIVE.CONTENT_FK,
+            CONTENT_DERIVATIVE.SOURCE_FK
         ).select(
-                dsl.select(
-                        field("derivedid", Int::class.java),
-                        field("sourceid", Int::class.java)
-                )
+            dsl.select(
+                field("derivedid", Int::class.java),
+                field("sourceid", Int::class.java)
+            )
+                .from(
+                    dsl.select(
+                        field("sourceid", Int::class.java),
+                        field("sourcesort", Int::class.java),
+                        COLLECTION_ENTITY.SLUG.`as`("sourcechapter")
+                    )
                         .from(
-                                dsl.select(
-                                        field("sourceid", Int::class.java),
-                                        field("sourcesort", Int::class.java),
-                                        COLLECTION_ENTITY.SLUG.`as`("sourcechapter")
+                            dsl.select(
+                                CONTENT_ENTITY.ID.`as`("sourceid"),
+                                CONTENT_ENTITY.SORT.`as`("sourcesort"),
+                                CONTENT_ENTITY.COLLECTION_FK.`as`("chapterid")
+                            ).from(CONTENT_ENTITY).where(
+                                CONTENT_ENTITY.COLLECTION_FK.`in`(
+                                    dsl
+                                        .select(COLLECTION_ENTITY.ID)
+                                        .from(COLLECTION_ENTITY)
+                                        .where(COLLECTION_ENTITY.PARENT_FK.eq(sourceId))
                                 )
-                                        .from(
-                                                dsl.select(
-                                                        CONTENT_ENTITY.ID.`as`("sourceid"),
-                                                        CONTENT_ENTITY.SORT.`as`("sourcesort"),
-                                                        CONTENT_ENTITY.COLLECTION_FK.`as`("chapterid")
-                                                ).from(CONTENT_ENTITY).where(
-                                                        CONTENT_ENTITY.COLLECTION_FK.`in`(
-                                                                dsl
-                                                                        .select(COLLECTION_ENTITY.ID)
-                                                                        .from(COLLECTION_ENTITY)
-                                                                        .where(COLLECTION_ENTITY.PARENT_FK.eq(sourceId))
-                                                        )
-                                                )
-                                        )
-                                        .leftJoin(COLLECTION_ENTITY)
-                                        .on(COLLECTION_ENTITY.ID.eq(field("chapterid", Int::class.java)))
+                            )
                         )
-                        .leftJoin(
-                                dsl
-                                        .select(
-                                                field("derivedid", Int::class.java),
-                                                field("derivedsort", Int::class.java),
-                                                COLLECTION_ENTITY.SLUG.`as`("derivedchapter")
-                                        )
-                                        .from(
-                                                dsl
-                                                        .select(
-                                                                CONTENT_ENTITY.ID.`as`("derivedid"),
-                                                                CONTENT_ENTITY.SORT.`as`("derivedsort"),
-                                                                CONTENT_ENTITY.COLLECTION_FK.`as`("chapterid")
-                                                        )
-                                                        .from(CONTENT_ENTITY)
-                                                        .where(CONTENT_ENTITY.COLLECTION_FK.`in`(
-                                                                dsl
-                                                                        .select(COLLECTION_ENTITY.ID)
-                                                                        .from(COLLECTION_ENTITY)
-                                                                        .where(COLLECTION_ENTITY.PARENT_FK.eq(projectId))
-                                                        ))
-                                        )
-                                        .leftJoin(COLLECTION_ENTITY)
-                                        .on(COLLECTION_ENTITY.ID.eq(field("chapterid", Int::class.java)))
+                        .leftJoin(COLLECTION_ENTITY)
+                        .on(COLLECTION_ENTITY.ID.eq(field("chapterid", Int::class.java)))
+                )
+                .leftJoin(
+                    dsl
+                        .select(
+                            field("derivedid", Int::class.java),
+                            field("derivedsort", Int::class.java),
+                            COLLECTION_ENTITY.SLUG.`as`("derivedchapter")
                         )
-                        .on(
-                                field("sourcesort", Int::class.java)
-                                        .eq(field("derivedsort", Int::class.java))
-                                        .and(field("sourcechapter", Int::class.java)
-                                                .eq(field("derivedchapter", Int::class.java)))
+                        .from(
+                            dsl
+                                .select(
+                                    CONTENT_ENTITY.ID.`as`("derivedid"),
+                                    CONTENT_ENTITY.SORT.`as`("derivedsort"),
+                                    CONTENT_ENTITY.COLLECTION_FK.`as`("chapterid")
+                                )
+                                .from(CONTENT_ENTITY)
+                                .where(
+                                    CONTENT_ENTITY.COLLECTION_FK.`in`(
+                                        dsl
+                                            .select(COLLECTION_ENTITY.ID)
+                                            .from(COLLECTION_ENTITY)
+                                            .where(COLLECTION_ENTITY.PARENT_FK.eq(projectId))
+                                    )
+                                )
                         )
+                        .leftJoin(COLLECTION_ENTITY)
+                        .on(COLLECTION_ENTITY.ID.eq(field("chapterid", Int::class.java)))
+                )
+                .on(
+                    field("sourcesort", Int::class.java)
+                        .eq(field("derivedsort", Int::class.java))
+                        .and(
+                            field("sourcechapter", Int::class.java)
+                                .eq(field("derivedchapter", Int::class.java))
+                        )
+                )
         ).execute()
     }
 

--- a/src/main/kotlin/org/wycliffeassociates/otter/jvm/persistence/repositories/CollectionRepository.kt
+++ b/src/main/kotlin/org/wycliffeassociates/otter/jvm/persistence/repositories/CollectionRepository.kt
@@ -78,7 +78,7 @@ class CollectionRepository(
                             if (deleteAudio) {
                                 val audioDirectory = directoryProvider.getProjectAudioDirectory(
                                         it.resourceContainer ?: throw RuntimeException("No source metadata found."),
-                                        project).parentFile
+                                        project)
                                 audioDirectory.deleteRecursively()
                             }
                         }.ignoreElement()


### PR DESCRIPTION
This PR fixes several things:
1. Alternate takes are faster to load. Previously, every time a take was emitted by a takes relay, it would be added to the alternateTakes list. This would update the observable list and force the list/flowpane to respond to the change and redraw. Now, the initial load of the takes adds all of the existing alternate takes to the list at the same time.
2. Drag target area has been fixed. (Previously, dragging a take to the area around the drag target could trigger the take to be selected.) Additionally, the overlap condition is now based on whether the dragging take overlaps the drag target, not whether the mouse cursor is over the drag target.
3. `activeProjectAudioDirectoryProperty` and `activeResourceSlugProperty` in WorkbookViewModel are now set by the app. Previously, these values were left unassigned which was causing IllegalStateExceptions. However, the manner in which these are set is not final.

Requires common [#117](https://github.com/WycliffeAssociates/otter-common/pull/117)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wycliffeassociates/otter-jvm/475)
<!-- Reviewable:end -->