### PR TITLE
 Disable colors in ktlint

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -277,4 +277,8 @@ tasks.withType(Test) {
             }
         }
     }
+
+    ktlint {
+        coloredOutput = false // Colors break source links in the IDEA console.
+    }
 }

--- a/src/main/kotlin/org/wycliffeassociates/otter/jvm/app/ui/projectwizard/viewmodel/ProjectWizardViewModel.kt
+++ b/src/main/kotlin/org/wycliffeassociates/otter/jvm/app/ui/projectwizard/viewmodel/ProjectWizardViewModel.kt
@@ -54,7 +54,6 @@ class ProjectWizardViewModel : ViewModel() {
         }
     }
 
-
     private fun filterSourceLanguages() {
         collectionRepo
             .getRootSources()


### PR DESCRIPTION
 Disable report colors in ktlint because they break source links in IDEA console.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wycliffeassociates/otter-jvm/484)
<!-- Reviewable:end -->
