### PR TITLE
use master for chromeabletabpane

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ cache:
     - $HOME/.gradle/caches/
     - $HOME/.gradle/wrapper
 install:
-  - git clone --branch=jbs-java11 https://github.com/WycliffeAssociates/chromeabletabpane.git ../chromeabletabpane
+  - git clone https://github.com/WycliffeAssociates/chromeabletabpane.git ../chromeabletabpane
   - git clone --branch=dev https://github.com/WycliffeAssociates/kotlin-resource-container.git ../kotlin-resource-container
   - git clone https://github.com/WycliffeAssociates/otter-common.git ../otter-common
   - export BRANCH=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo $TRAVIS_BRANCH; else echo $TRAVIS_PULL_REQUEST_BRANCH; fi)


### PR DESCRIPTION
Javafx 11 changes have been made to the chromeabletabpane; we can stop using the feature branch for builds

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wycliffeassociates/otter-jvm/497)
<!-- Reviewable:end -->
