### PR TITLE
Disable back button when back stack is empty

### DIFF
--- a/src/main/kotlin/org/wycliffeassociates/otter/jvm/app/ui/chromeablestage/ChromeableStage.kt
+++ b/src/main/kotlin/org/wycliffeassociates/otter/jvm/app/ui/chromeablestage/ChromeableStage.kt
@@ -1,5 +1,6 @@
 package org.wycliffeassociates.otter.jvm.app.ui.chromeablestage
 
+import javafx.beans.property.SimpleBooleanProperty
 import javafx.scene.Node
 import org.wycliffeassociates.controls.ChromeableTabPane
 import org.wycliffeassociates.otter.common.navigation.INavigator
@@ -13,6 +14,7 @@ import java.util.*
 class ChromeableStage : UIComponent(), ScopedInstance, INavigator {
     val chrome: Node by param()
     val headerScalingFactor: Double by param()
+    val canNavigateBackProperty = SimpleBooleanProperty(false)
 
     override val tabGroupMap: MutableMap<TabGroupType, ITabGroup> = mutableMapOf()
     override val navBackStack = Stack<ITabGroup>()
@@ -35,5 +37,19 @@ class ChromeableStage : UIComponent(), ScopedInstance, INavigator {
                 }
             }
         }
+    }
+
+    override fun back() {
+        super.back()
+        setCanNavigateBack()
+    }
+
+    override fun navigateTo(tabGroupType: TabGroupType) {
+        super.navigateTo(tabGroupType)
+        setCanNavigateBack()
+    }
+
+    private fun setCanNavigateBack() {
+        canNavigateBackProperty.set(navBackStack.isNotEmpty())
     }
 }

--- a/src/main/kotlin/org/wycliffeassociates/otter/jvm/app/ui/mainscreen/view/MainScreenView.kt
+++ b/src/main/kotlin/org/wycliffeassociates/otter/jvm/app/ui/mainscreen/view/MainScreenView.kt
@@ -88,6 +88,7 @@ class MainScreenView : View() {
                     navButton {
                         text = messages["back"]
                         graphic = AppStyles.backIcon()
+                        enableWhen(chromeableStage.canNavigateBackProperty)
                         action {
                             chromeableStage.back()
                         }


### PR DESCRIPTION
The back button is now only enabled when the navigation back stack is not empty. This prevents a crash that would happen when the user would click the back button even though the back stack was emtpy. This PR is in addition to common [#131](https://github.com/WycliffeAssociates/otter-common/pull/131) which actually checks the stack before performing the back() operation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wycliffeassociates/otter-jvm/499)
<!-- Reviewable:end -->
